### PR TITLE
Integrate emulator and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,19 @@ jobs:
       run: sudo apt install libcunit1 libcunit1-doc libcunit1-dev
 
 # clean
-    - name: make clean
+    - name: cleaning up
       run: make clean
 
 # build
-    - name: make
+    - name: building applications
       run: make
 
 # linter - TODO
 
 # testing - TODO
+    - name: testing build
+      run: make test
+
+# clean up
+    - name: cleaning up
+      run: make clean

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/checkout@v3
 
 # install dependencies - TODO
+    - name: install cunit
+      run: sudo apt install libcunit1 libcunit1-doc libcunit1-dev
 
 # clean
     - name: make clean

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,6 @@
 name: CI
 
-on:
-  push: 
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - main
-      - develop
+on: [push,pull_request]
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,31 @@ CC = clang
 # compiler flags
 CFLAGS = -g -W -Wall -Wextra -pedantic
 
-# libraries to load
-LIBS = 
-
 # targets to build
-TARGETS = disassembler_8080 emulator
+TARGETS = disassembler_8080 shell
 
-# build all targets (default)
+# build all non-testing executables
 all: $(TARGETS)
 
-$(TARGETS): % : %.c
-	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+# build disassembler executable
+disassembler_8080:
+	$(CC) $(CFLAGS) -o disassembler_8080 disassembler_8080.c
 
-# run tests
-test:
+# build emulator object
+emulator:
+	$(CC) $(CFLAGS) -c emulator.c
+
+# build shell executable
+shell: emulator
+	$(CC) $(CFLAGS) -c shell.c
+	$(CC) $(CFLAGS) -o shell shell.o emulator.o
+
+# build tests executable and run tests
+test: emulator
+	$(CC) $(CFLAGS) -c tests.c
+	$(CC) $(CFLAGS) -o tests tests.o emulator.o -lcunit
+	./tests
 
 # removes existing objects and executables
 clean:
-	$(RM) *.o $(TARGETS)
+	$(RM) *.o emulator tests shell disassembler_8080

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ CFLAGS = -g -W -Wall -Wextra -pedantic
 LIBS = 
 
 # targets to build
-TARGETS = disassembler_8080
+TARGETS = disassembler_8080 emulator
 
 # build all targets (default)
 all: $(TARGETS)
 
-$(TARGETS): $(TARGETS).c
-	$(CC) $(CFLAGS) -o $(TARGETS) $(TARGETS).c $(LIBS)
+$(TARGETS): % : %.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 # run tests
 test:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 An Intel 8080 emulator to run Space Invaders. OSU Senior Capstone Project - Spring 2023
 
 ## Installation
-- Run "make" to build both the disassembler and the emulator shell
+- Run "make" to build both the disassembler, the emulator, and the shell
+- Run "make disassembler_8080" to build just the disassembler
+- Run "make shell" to build just the emulator and its shell
 - Run "make test" to build and run the tests executable
 - Run "make clean" to remove all object files and executables
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # space-invaders-8080-emulator
 An Intel 8080 emulator to run Space Invaders. OSU Senior Capstone Project - Spring 2023
+
+## Installation
+- Run "make" to build both the disassembler and the emulator shell
+- Run "make test" to build and run the tests executable
+- Run "make clean" to remove all object files and executables
+
+## Running the Emulator
+- After building the emulator and its shell, run `./shell file' to run the emulator with the ROM file as an argument.

--- a/README.md
+++ b/README.md
@@ -8,5 +8,8 @@ An Intel 8080 emulator to run Space Invaders. OSU Senior Capstone Project - Spri
 - Run "make test" to build and run the tests executable
 - Run "make clean" to remove all object files and executables
 
+## Running the Disassembler
+- After building the disassembler, run `./disassembler_8080 file_path` to disassemble the ROM with the ROM file path as an argument.
+
 ## Running the Emulator
-- After building the emulator and its shell, run `./shell file' to run the emulator with the ROM file as an argument.
+- After building the emulator and its shell, run `./shell file_path` to run the emulator with the ROM file path as an argument.

--- a/emulator.c
+++ b/emulator.c
@@ -1,0 +1,162 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#define MEM_SIZE 65536
+
+typedef struct {
+  // Registers
+  uint8_t a;
+  uint8_t b;
+  uint8_t c;
+  uint8_t d;
+  uint8_t e;
+  uint8_t h;
+  uint8_t l;
+
+  // Flags (stored in the F register)
+  // Includes z, s, p, cy, ac, pad
+
+  uint8_t flags;
+
+  /*
+  Sign (S): Set if the result of an operation is negative (most significant bit is 1).
+  Zero (Z): Set if the result of an operation is zero.
+  Auxiliary Carry (AC): Set if there's a carry from bit 3 to bit 4 during an operation.
+  Parity (P): Set if the result of an operation has an even number of 1 bits.
+  Carry (CY): Set if there's a carry from the most significant bit after an operation.
+  */
+
+  // Program Counter & Stack pointer
+
+  uint16_t pc, sp;
+
+  // Memory
+
+  uint8_t memory[MEM_SIZE];
+
+  // Internal state for interrupt tracking and halted status tracking
+
+  bool interrupt_enabled;
+  bool halted;
+
+} i8080;
+
+// Funct prototypes
+void cpu_init(i8080 *cpu);
+uint8_t cpu_read_mem(i8080 *cpu, uint16_t address);
+void cpu_write_mem(i8080 *cpu, uint16_t address, uint8_t data);
+bool cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address);
+
+// Prototypes for Flags
+
+void cpu_set_flag(i8080 *cpu, uint8_t flag, bool value);
+bool cpu_get_flag(i8080 *cpu, uint8_t flag);
+
+
+// Execute Instruction
+
+void execute_instruction(i8080 *cpu, uint8_t opcode) {
+  switch (opcode){
+    ;
+
+  }
+
+}
+void cpu_init(i8080 *cpu) {
+  cpu -> a = 0;
+  cpu -> b = 0;
+  cpu -> c = 0;
+  cpu -> d = 0;
+  cpu -> e = 0;
+  cpu -> h = 0;
+  cpu -> l = 0;
+
+  cpu -> flags = 0;
+  cpu -> pc = 0;
+  cpu -> sp = 0;
+  cpu -> interrupt_enabled = false;
+  cpu -> halted = false;
+
+}
+
+uint8_t cpu_read_mem(i8080 *cpu, uint16_t address){
+  return cpu->memory[address];
+
+}
+
+void cpu_write_mem(i8080 *cpu, uint16_t address, uint8_t data) {
+  cpu->memory[address] = data;
+}
+bool cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address){
+
+  FILE *file = fopen(file_path, "rb");
+  if (file == NULL){
+      printf("Error: Unable to open file %s\n", file_path);
+      return false;
+  }
+  fseek(file, 0, SEEK_END);
+  long file_size = ftell(file);
+  fseek(file, 0, SEEK_SET);
+
+  if (address + file_size > MEM_SIZE) {
+    printf("Error: File size exceeds available memory\n");
+    fclose(file);
+    return false;
+  }
+  size_t bytes_read = fread(&cpu->memory[address], 1, file_size, file);
+  fclose(file);
+
+  if (bytes_read != file_size){
+    printf("Error: Unable to read the entire file into memory\n");
+    return false;
+  }
+  return true;
+}
+
+int main() {
+  i8080 cpu;
+  cpu_init(&cpu);
+  const char *rom_path = "./invaders";
+  uint16_t load_address = 0x0000;
+  // Load ROM
+  if (!cpu_load_file(&cpu, rom_path, load_address)){
+    printf("Failed to load ROM\n");
+    return 1;
+
+  }
+
+  while (true) {
+
+    // 1 Fetch, decode, and execute next instruction
+    // fetch_decode_execute(&cpu)
+
+    // 2 Handle interrupts
+    // handle_interrupts(&cpu)
+
+    // 3 Update system state for display, input, and sound
+
+    // 4 Check for exit conditions
+
+  }
+
+  // Clean up resources and exit
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/emulator.c
+++ b/emulator.c
@@ -54,7 +54,7 @@ bool cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address) {
   }
 
   fseek(file, 0, SEEK_END);
-  long file_size = ftell(file);
+  size_t file_size = ftell(file);
   fseek(file, 0, SEEK_SET);
 
   if (address + file_size > MEM_SIZE) {

--- a/emulator.c
+++ b/emulator.c
@@ -2,64 +2,19 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
-
-#define MEM_SIZE 65536
-
-typedef struct {
-  // Registers
-  uint8_t a;
-  uint8_t b;
-  uint8_t c;
-  uint8_t d;
-  uint8_t e;
-  uint8_t h;
-  uint8_t l;
-
-  // Flags (stored in the F register)
-  // Includes z, s, p, cy, ac, pad
-
-  uint8_t flags;
-
-  /*
-  Sign (S): Set if the result of an operation is negative (most significant bit is 1).
-  Zero (Z): Set if the result of an operation is zero.
-  Auxiliary Carry (AC): Set if there's a carry from bit 3 to bit 4 during an operation.
-  Parity (P): Set if the result of an operation has an even number of 1 bits.
-  Carry (CY): Set if there's a carry from the most significant bit after an operation.
-  */
-
-  // Program Counter & Stack pointer
-
-  uint16_t pc, sp;
-
-  // Memory
-
-  uint8_t memory[MEM_SIZE];
-
-  // Internal state for interrupt tracking and halted status tracking
-
-  bool interrupt_enabled;
-  bool halted;
-
-} i8080;
-
-// Funct prototypes
-void cpu_init(i8080 *cpu);
-uint8_t cpu_read_mem(i8080 *cpu, uint16_t address);
-void cpu_write_mem(i8080 *cpu, uint16_t address, uint8_t data);
-bool cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address);
-
-// Prototypes for Flags
-
-void cpu_set_flag(i8080 *cpu, uint8_t flag, bool value);
-bool cpu_get_flag(i8080 *cpu, uint8_t flag);
-
+#include "emulator.h"
 
 // Execute Instruction
-
 void execute_instruction(i8080 *cpu, uint8_t opcode) {
-  switch (opcode){
-    ;
+  switch (opcode) {
+    case 0x13: {    //INX D
+      cpu->e += 1;
+      if (cpu->e == 0) {
+        cpu->d += 1;
+      }
+      cpu->pc += 1;
+      break;
+    }
 
   }
 
@@ -114,49 +69,3 @@ bool cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address){
   }
   return true;
 }
-
-int main() {
-  i8080 cpu;
-  cpu_init(&cpu);
-  const char *rom_path = "./invaders";
-  uint16_t load_address = 0x0000;
-  // Load ROM
-  if (!cpu_load_file(&cpu, rom_path, load_address)){
-    printf("Failed to load ROM\n");
-    return 1;
-
-  }
-
-  while (true) {
-
-    // 1 Fetch, decode, and execute next instruction
-    // fetch_decode_execute(&cpu)
-
-    // 2 Handle interrupts
-    // handle_interrupts(&cpu)
-
-    // 3 Update system state for display, input, and sound
-
-    // 4 Check for exit conditions
-
-  }
-
-  // Clean up resources and exit
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/emulator.h
+++ b/emulator.h
@@ -1,0 +1,50 @@
+#define MEM_SIZE 65536
+
+typedef struct {
+  // Registers
+  uint8_t a;
+  uint8_t b;
+  uint8_t c;
+  uint8_t d;
+  uint8_t e;
+  uint8_t h;
+  uint8_t l;
+
+  // Flags (stored in the F register)
+  // Includes z, s, p, cy, ac, pad
+
+  uint8_t flags;
+
+  /*
+  Sign (S): Set if the result of an operation is negative (most significant bit is 1).
+  Zero (Z): Set if the result of an operation is zero.
+  Auxiliary Carry (AC): Set if there's a carry from bit 3 to bit 4 during an operation.
+  Parity (P): Set if the result of an operation has an even number of 1 bits.
+  Carry (CY): Set if there's a carry from the most significant bit after an operation.
+  */
+
+  // Program Counter & Stack pointer
+
+  uint16_t pc, sp;
+
+  // Memory
+
+  uint8_t memory[MEM_SIZE];
+
+  // Internal state for interrupt tracking and halted status tracking
+
+  bool interrupt_enabled;
+  bool halted;
+
+} i8080;
+
+// Funct prototypes
+void cpu_init(i8080 *cpu);
+uint8_t cpu_read_mem(i8080 *cpu, uint16_t address);
+void cpu_write_mem(i8080 *cpu, uint16_t address, uint8_t data);
+bool cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address);
+void execute_instruction(i8080 *cpu, uint8_t opcode);
+
+// Prototypes for Flags
+void cpu_set_flag(i8080 *cpu, uint8_t flag, bool value);
+bool cpu_get_flag(i8080 *cpu, uint8_t flag);

--- a/shell.c
+++ b/shell.c
@@ -17,8 +17,6 @@ int main() {
   }
 
   while (true) {
-    printf("pc: %d, e: %d, d: %d\n", cpu.pc, cpu.e, cpu.d);
-    execute_instruction(&cpu, 0x13);
 
     // 1 Fetch, decode, and execute next instruction
     // fetch_decode_execute(&cpu)

--- a/shell.c
+++ b/shell.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "emulator.h"
+
+int main() {
+  i8080 cpu;
+  cpu_init(&cpu);
+  const char *rom_path = "./invaders";
+  uint16_t load_address = 0x0000;
+  // Load ROM
+  if (!cpu_load_file(&cpu, rom_path, load_address)){
+    printf("Failed to load ROM\n");
+    return 1;
+
+  }
+
+  while (true) {
+    printf("pc: %d, e: %d, d: %d\n", cpu.pc, cpu.e, cpu.d);
+    execute_instruction(&cpu, 0x13);
+
+    // 1 Fetch, decode, and execute next instruction
+    // fetch_decode_execute(&cpu)
+
+    // 2 Handle interrupts
+    // handle_interrupts(&cpu)
+
+    // 3 Update system state for display, input, and sound
+
+    // 4 Check for exit conditions
+
+  }
+
+  // Clean up resources and exit
+}

--- a/tests.c
+++ b/tests.c
@@ -1,15 +1,9 @@
-<<<<<<< HEAD
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <CUnit/Basic.h>
 #include "emulator.h"
-=======
-#include <stdio.h>
-#include <CUnit/Basic.h>
-/* Need to include header file to import structures and emulator function */
->>>>>>> develop
 
 /* Open any necessary files for test suite here */
 int init_opcodes_suite(void)
@@ -34,7 +28,6 @@ void test_func2(void)
 	;
 }
 
-<<<<<<< HEAD
 void test_opcode_0x13(void)
 {
   i8080 cpu;
@@ -46,8 +39,6 @@ void test_opcode_0x13(void)
   CU_ASSERT(cpu.d == 0);
 }
 
-=======
->>>>>>> develop
 int main(void)
 {
 	CU_pSuite pSuite = NULL;
@@ -67,12 +58,8 @@ int main(void)
 	 * argument with the test function name.
 	*/
 	if ((NULL == CU_add_test(pSuite, "test of test_func()", test_func)) ||
-<<<<<<< HEAD
 		(NULL == CU_add_test(pSuite, "test of test_func2()", test_func2)) ||
     (NULL == CU_add_test(pSuite, "test of test_opcode_0x13()", test_func2)))
-=======
-		(NULL == CU_add_test(pSuite, "test of test_func2()", test_func2)))
->>>>>>> develop
 	{
 		CU_cleanup_registry();
 		return CU_get_error();
@@ -82,8 +69,4 @@ int main(void)
 	CU_basic_run_tests();
 	CU_cleanup_registry();
 	return CU_get_error();
-<<<<<<< HEAD
 }
-=======
-}
->>>>>>> develop

--- a/tests.c
+++ b/tests.c
@@ -1,0 +1,72 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <CUnit/Basic.h>
+#include "emulator.h"
+
+/* Open any necessary files for test suite here */
+int init_opcodes_suite(void)
+{
+	return 0;
+}
+
+/* Close anything that was opened here for test suite */
+int clean_suite(void)
+{
+	return 0;
+}
+
+/* Add tests here */
+void test_func(void)
+{
+	;
+}
+
+void test_func2(void)
+{
+	;
+}
+
+void test_opcode_0x13(void)
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+  execute_instruction(&cpu, 0x13);
+
+  CU_ASSERT(cpu.pc == 1);
+  CU_ASSERT(cpu.e == 1);
+  CU_ASSERT(cpu.d == 0);
+}
+
+int main(void)
+{
+	CU_pSuite pSuite = NULL;
+
+	if (CUE_SUCCESS != CU_initialize_registry())
+		return CU_get_error();
+
+	pSuite = CU_add_suite("opcodes", init_opcodes_suite, clean_suite);
+		if (NULL == pSuite) {
+			CU_cleanup_registry();
+			return CU_get_error();
+	   	}
+	
+	/* 
+	 * Add new tests to this statement.  Replace the second argument of
+	 * CU_add_test with an output string for running the test, and the third
+	 * argument with the test function name.
+	*/
+	if ((NULL == CU_add_test(pSuite, "test of test_func()", test_func)) ||
+		(NULL == CU_add_test(pSuite, "test of test_func2()", test_func2)) ||
+    (NULL == CU_add_test(pSuite, "test of test_opcode_0x13()", test_func2)))
+	{
+		CU_cleanup_registry();
+		return CU_get_error();
+	}
+
+	CU_basic_set_mode(CU_BRM_VERBOSE);
+	CU_basic_run_tests();
+	CU_cleanup_registry();
+	return CU_get_error();
+}


### PR DESCRIPTION
# Code Refactoring:
- emulator.c refactored into two files: emulator.c and shell.c. Emulator.c holds all the functions and struct for the processor, where shell.c holds the logic for running the emulator.
- emulator.h created so shell.c and tests.c can both access the emulator's functions

# Opcode implementation
- opcode 0x13 implemented in emulator.c's execute_instruction
- opcode 0x13 test case added to tests.c - unit test passing

# Makefile update
- Makefile can now build and run tests via `make test`
- Makefile can now build the shell via `make` or `make shell`
- Makefile compiles and links emulator.c to shell and tests when building either executable
- Makefile cleans up all executables and object files via `make clean`

# README update
- provides installation instructions

# CI update
- The CI virtual environment now installs cunit
- On push/pull requests, the runner now builds tests.c and executes it as a condition for passing status checks
- The CI virtual environment cleans up before building and after running all tests