### PR TITLE
Fetch execute loop

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 // Execute Instruction
-void
+int
 execute_instruction(i8080 *cpu, uint8_t opcode)
 {
   switch (opcode)
@@ -22,7 +22,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->pc += 1;
         break;
       }
+      default:
+      {
+        cpu->pc += 1;
+        fprintf(stderr, "Error: opcode 0x%02x not found\n", opcode);
+        return -1;
+      }
     }
+  return 0;
 }
 
 void
@@ -62,17 +69,24 @@ cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address)
 
   if (file == NULL)
     {
-      printf("Error: Unable to open file %s\n", file_path);
+      fprintf(stderr, "Error: Unable to open file %s\n", file_path);
       return false;
     }
 
   fseek(file, 0, SEEK_END);
   size_t file_size = ftell(file);
+
+  if (file_size < 0)
+    {
+      perror("Error: unable to obtain file size");
+      return false;
+    }
+    
   fseek(file, 0, SEEK_SET);
 
   if (address + file_size > MEM_SIZE)
     {
-      printf("Error: File size exceeds available memory\n");
+      fprintf(stderr, "Error: File size exceeds available memory\n");
       fclose(file);
       return false;
     }
@@ -82,7 +96,7 @@ cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address)
 
   if (bytes_read != file_size)
     {
-      printf("Error: Unable to read the entire file into memory\n");
+      fprintf(stderr, "Error: Unable to read the entire file into memory\n");
       return false;
     }
 

--- a/emulator.c
+++ b/emulator.c
@@ -19,16 +19,15 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             cpu->d += 1;
           }
 
-        cpu->pc += 1;
         break;
       }
-      default:
+    default:
       {
-        cpu->pc += 1;
         fprintf(stderr, "Error: opcode 0x%02x not found\n", opcode);
         return -1;
       }
     }
+  cpu->pc += 1;
   return 0;
 }
 
@@ -81,7 +80,7 @@ cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address)
       perror("Error: unable to obtain file size");
       return false;
     }
-    
+
   fseek(file, 0, SEEK_SET);
 
   if (address + file_size > MEM_SIZE)

--- a/emulator.h
+++ b/emulator.h
@@ -48,7 +48,7 @@ void cpu_init(i8080 *cpu);
 uint8_t cpu_read_mem(i8080 *cpu, uint16_t address);
 void cpu_write_mem(i8080 *cpu, uint16_t address, uint8_t data);
 bool cpu_load_file(i8080 *cpu, const char *file_path, uint16_t address);
-void execute_instruction(i8080 *cpu, uint8_t opcode);
+int execute_instruction(i8080 *cpu, uint8_t opcode);
 
 // Prototypes for Flags
 void cpu_set_flag(i8080 *cpu, uint8_t flag, bool value);

--- a/shell.c
+++ b/shell.c
@@ -5,24 +5,36 @@
 #include <stdlib.h>
 
 int
-main()
+main(int argc, char *argv[])
 {
+  // Only accept one argument
+  if (argc != 2)
+    {
+      fprintf(stderr, "Invalid number of arguments. Correct syntax: ./shell rom_filepath\n");
+      exit(EXIT_FAILURE);
+    }
+
+  // initialize CPU state
   i8080 cpu;
   cpu_init(&cpu);
-  const char *rom_path = "./invaders";
   uint16_t load_address = 0x0000;
-  // Load ROM
-  if (!cpu_load_file(&cpu, rom_path, load_address))
+
+  // Load ROM into memory
+  if (!cpu_load_file(&cpu, argv[1], load_address))
     {
-      printf("Failed to load ROM\n");
-      return 1;
+      fprintf(stderr, "Failed to load ROM\n");
+      exit(EXIT_FAILURE);
     }
 
   while (true)
     {
-
-      // 1 Fetch, decode, and execute next instruction
-      // fetch_decode_execute(&cpu)
+      // fetch and execute next instruction
+      uint8_t next_instruction = cpu_read_mem(&cpu, cpu.pc);
+      if (execute_instruction(&cpu, next_instruction) < 0) 
+        {
+          fprintf(stderr, "Unimplemented opcode encountered. Exiting program.\n");
+          exit(EXIT_FAILURE);
+        }
 
       // 2 Handle interrupts
       // handle_interrupts(&cpu)

--- a/shell.c
+++ b/shell.c
@@ -10,7 +10,8 @@ main(int argc, char *argv[])
   // Only accept one argument
   if (argc != 2)
     {
-      fprintf(stderr, "Invalid number of arguments. Correct syntax: ./shell rom_filepath\n");
+      fprintf(stderr, "Invalid number of arguments. Correct syntax: ./shell "
+                      "rom_filepath\n");
       exit(EXIT_FAILURE);
     }
 
@@ -30,9 +31,10 @@ main(int argc, char *argv[])
     {
       // fetch and execute next instruction
       uint8_t next_instruction = cpu_read_mem(&cpu, cpu.pc);
-      if (execute_instruction(&cpu, next_instruction) < 0) 
+      if (execute_instruction(&cpu, next_instruction) < 0)
         {
-          fprintf(stderr, "Unimplemented opcode encountered. Exiting program.\n");
+          fprintf(stderr,
+                  "Unimplemented opcode encountered. Exiting program.\n");
           exit(EXIT_FAILURE);
         }
 

--- a/tests.c
+++ b/tests.c
@@ -43,6 +43,13 @@ test_opcode_0x13(void)
   CU_ASSERT(cpu.pc == 1);
   CU_ASSERT(cpu.e == 1);
   CU_ASSERT(cpu.d == 0);
+
+  cpu.e = 0xFF;
+  code_found = execute_instruction(&cpu, 0x13);
+  CU_ASSERT(code_found == 0);
+  CU_ASSERT(cpu.pc == 2);
+  CU_ASSERT(cpu.e == 0);
+  CU_ASSERT(cpu.d == 1);
 }
 
 int

--- a/tests.c
+++ b/tests.c
@@ -37,8 +37,9 @@ test_opcode_0x13(void)
 {
   i8080 cpu;
   cpu_init(&cpu);
-  execute_instruction(&cpu, 0x13);
+  int code_found = execute_instruction(&cpu, 0x13);
 
+  CU_ASSERT(code_found == 0);
   CU_ASSERT(cpu.pc == 1);
   CU_ASSERT(cpu.e == 1);
   CU_ASSERT(cpu.d == 0);


### PR DESCRIPTION
### Fetch + Execute added to shell.c
- Part of the main shell loop is now implemented. It finds the next opcode based on the cpu's program counter. It then passes the opcode and cpu into execute_instruction to execute the opcode. Basic error handling added to exit loop if unknown opcode identified.

### ROM file path now passed as argument
- The space invaders ROM's filepath is no longer hardcoded into shell.c. the filepath is passed as the first (and only) argument when executing the program. Basic error handling added to fail and exit if the incorrect number of arguments are passed.

### Modification to execute_instructions function
- Execute instructions now returns an integer instead of void. 0 returned if no errors occurred during execution. -1 returned if error encountered (namely: opcode not found). 
- Default case added in opcode switch statement for unknown opcodes. Prints error message and returns -1.

### Test Suite
- Opcode 0x13's unit test expanded to test scenario where register e overflows.