### PR TITLE
Bugfix 0x1a

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -130,8 +130,8 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         // get value at addr
         uint8_t val = cpu_read_mem(cpu, addr);
 
-        // put value in d
-        cpu->d = val;
+        // put value in a
+        cpu->a = val;
         break;
       }
     case 0x21: // NOLINT

--- a/tests.c
+++ b/tests.c
@@ -670,7 +670,8 @@ test_opcode_0xc3(void) // NOLINT
 }
 
 void
-test_opcode_0x1a(void) // NOLINT
+test_opcode_
+(void) // NOLINT
 {                      // LDAX D
 
   // setup
@@ -686,7 +687,7 @@ test_opcode_0x1a(void) // NOLINT
   // verify
   CU_ASSERT(0 == code_found);
   CU_ASSERT(1 == cpu.pc);
-  CU_ASSERT(0xCC == cpu.d); // NOLINT
+  CU_ASSERT(0xCC == cpu.a); // NOLINT
 
   // cleanup
   cpu_write_mem(&cpu, 0x0001, 0x00); // NOLINT

--- a/tests.c
+++ b/tests.c
@@ -670,8 +670,7 @@ test_opcode_0xc3(void) // NOLINT
 }
 
 void
-test_opcode_
-(void) // NOLINT
+test_opcode_0x1a(void) // NOLINT
 {                      // LDAX D
 
   // setup


### PR DESCRIPTION
Doing some debugging 0x1a (LDAX D) was putting the value in the wrong register.