### PR TITLE
Bugfix 0xcd

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -369,8 +369,8 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       }
     case 0xcd:                                             // NOLINT
       {                                                    // CALL ADDR
-        cpu_write_mem(cpu, cpu->sp - 1, (cpu->pc >> 8));   // NOLINT
-        cpu_write_mem(cpu, cpu->sp - 2, (cpu->pc & 0xFF)); // NOLINT
+        cpu_write_mem(cpu, cpu->sp - 1, ((cpu->pc + 3) >> 8));   // NOLINT
+        cpu_write_mem(cpu, cpu->sp - 2, ((cpu->pc +3) & 0xFF)); // NOLINT
 
         cpu->sp -= 2;
         cpu->pc = (cpu_read_mem(cpu, cpu->pc + 2) << 8) // NOLINT

--- a/emulator.c
+++ b/emulator.c
@@ -367,10 +367,10 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->pc = address;
         return 0;
       }
-    case 0xcd:                                             // NOLINT
-      {                                                    // CALL ADDR
+    case 0xcd:                                                   // NOLINT
+      {                                                          // CALL ADDR
         cpu_write_mem(cpu, cpu->sp - 1, ((cpu->pc + 3) >> 8));   // NOLINT
-        cpu_write_mem(cpu, cpu->sp - 2, ((cpu->pc +3) & 0xFF)); // NOLINT
+        cpu_write_mem(cpu, cpu->sp - 2, ((cpu->pc + 3) & 0xFF)); // NOLINT
 
         cpu->sp -= 2;
         cpu->pc = (cpu_read_mem(cpu, cpu->pc + 2) << 8) // NOLINT

--- a/emulator.c
+++ b/emulator.c
@@ -14,7 +14,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
   switch (opcode)
     {
     case 0x00: // NOLINT
-      // printf("NOP");
+      // NOP
       break;
     case 0x01: // NOLINT
       {        // LXI B
@@ -464,7 +464,6 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         // printf("EI");
         cpu->interrupt_enabled = true;
         return 0;
-        // break;
       }
     case 0xfe: // NOLINT
       {        // CPI

--- a/tests.c
+++ b/tests.c
@@ -641,7 +641,7 @@ test_opcode_0xcd(void) // NOLINT
 
   CU_ASSERT(code_found == 0);
   CU_ASSERT_EQUAL(cpu_read_mem(&cpu, temp - 1), 0xAB); // NOLINT
-  CU_ASSERT_EQUAL(cpu_read_mem(&cpu, temp - 2), 0xCD); // NOLINT
+  CU_ASSERT_EQUAL(cpu_read_mem(&cpu, temp - 2), 0xD0); // NOLINT
   CU_ASSERT_EQUAL(cpu.sp, 0xDCBA - 2);                 // NOLINT
   CU_ASSERT_EQUAL(cpu.pc, 0xEFFE);                     // NOLINT
 


### PR DESCRIPTION
CALL adr needs to put the address of next instruction from PC on the stack rather than the current address in PC.