### PR TITLE
Added print and debug options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ An Intel 8080 emulator to run Space Invaders. OSU Senior Capstone Project - Spri
 - After building the disassembler, run `./disassembler_8080 file_path` to disassemble the ROM with the ROM file path as an argument.
 
 ## Running the Emulator
-- After building the emulator and its shell, run `./shell file_path` to run the emulator with the ROM file path as an argument.
+- After building the emulator and its shell, run `./shell -[options] file_path` to run the emulator with the ROM file path as an argument.
+- Options:
+  - -p to print instructions as they are executed
+  - -d to print cpu state before and after instructions are executed
 
 [![cpp-linter](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml)

--- a/emulator.c
+++ b/emulator.c
@@ -658,7 +658,8 @@ print_instruction(uint8_t opcode)
 void
 print_state(i8080 *cpu)
 {
-  printf("REGISTERS a: 0x%x b: 0x%x c: 0x%x d: 0x%x e: 0x%x h: 0x%x l: 0x%x ",
+  printf("REGISTERS a: 0x%02x b: 0x%02x c: 0x%02x d: 0x%02x e: 0x%02x h: "
+         "0x%02x l: 0x%02x ",
          cpu->a, cpu->b, cpu->c, cpu->d, cpu->e, cpu->h, cpu->l);
 }
 

--- a/emulator.c
+++ b/emulator.c
@@ -8,9 +8,6 @@
 int
 execute_instruction(i8080 *cpu, uint8_t opcode)
 {
-  print_instruction(opcode);
-  printf("\nPRE-INSTRUCTION ");
-  print_state(cpu);
   switch (opcode)
     {
     case 0x00: // NOLINT
@@ -484,8 +481,6 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         return -1;
       }
     }
-  printf("POST-INSTRUCTION ");
-  print_state(cpu);
   cpu->pc += 1;
   return 0;
 }
@@ -652,16 +647,25 @@ update_sign_flag(i8080 *cpu, uint8_t result)
     }
 }
 
+// DEBUGGING FUNCTIONS
+
 void
 print_instruction(uint8_t opcode)
 {
-  printf("INSTRUCTION: 0x%x ", opcode);
+  printf("INSTRUCTION: 0x%02x\n", opcode);
 }
 
 void
 print_state(i8080 *cpu)
 {
-  printf("REGISTERS a: 0x%x b: 0x%x c: 0x%x d: 0x%x e: 0x%x h: 0x%x l: 0x%x "
-         "FLAGS: 0x%x\n",
-         cpu->a, cpu->b, cpu->c, cpu->d, cpu->e, cpu->h, cpu->l, cpu->flags);
+  printf("REGISTERS a: 0x%x b: 0x%x c: 0x%x d: 0x%x e: 0x%x h: 0x%x l: 0x%x ",
+         cpu->a, cpu->b, cpu->c, cpu->d, cpu->e, cpu->h, cpu->l);
+}
+
+void
+print_flags(uint8_t flags)
+{
+  printf("FLAGS z: %d s: %d p: %d cy: %d ac %d",
+         (flags & FLAG_Z) == FLAG_Z, (flags & FLAG_S) == FLAG_S, (flags & FLAG_P) == FLAG_P,
+         (flags & FLAG_CY) == FLAG_CY, (flags & FLAG_AC) == FLAG_AC);
 }

--- a/emulator.c
+++ b/emulator.c
@@ -665,7 +665,7 @@ print_state(i8080 *cpu)
 void
 print_flags(uint8_t flags)
 {
-  printf("FLAGS z: %d s: %d p: %d cy: %d ac %d",
-         (flags & FLAG_Z) == FLAG_Z, (flags & FLAG_S) == FLAG_S, (flags & FLAG_P) == FLAG_P,
+  printf("FLAGS z: %d s: %d p: %d cy: %d ac %d", (flags & FLAG_Z) == FLAG_Z,
+         (flags & FLAG_S) == FLAG_S, (flags & FLAG_P) == FLAG_P,
          (flags & FLAG_CY) == FLAG_CY, (flags & FLAG_AC) == FLAG_AC);
 }

--- a/emulator.h
+++ b/emulator.h
@@ -82,3 +82,4 @@ Helper functions to print instruction and cpu state
 */
 void print_instruction(uint8_t opcode);
 void print_state(i8080 *cpu);
+void print_flags(uint8_t flags);

--- a/shell.c
+++ b/shell.c
@@ -1,17 +1,48 @@
 #include "emulator.h"
+#include <ctype.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 int
 main(int argc, char *argv[])
 {
-  // Only accept one argument
-  if (argc != 2)
+  int pflag = 0;
+  int dflag = 0;
+  int opt;
+
+  while ((opt = getopt(argc, argv, "pd")) != -1)
+  {
+    switch (opt)
     {
-      fprintf(stderr, "Invalid number of arguments. Correct syntax: ./shell "
-                      "rom_filepath\n");
+      case 'p':
+        pflag = 1;
+        break;
+      case 'd':
+        dflag = 1;
+        break;
+      case '?':
+        if (isprint(optopt))
+          {
+            fprintf(stderr, "Unknown option '-%c'.\n", optopt);
+          }
+        else
+          {
+            fprintf(stderr, "Unknown option character '\\x%x.\n", optopt);
+          }
+        exit(EXIT_FAILURE);
+      default:
+        abort();
+    }
+  }
+
+  // Only accept one non-option argument
+  if ((argc - optind) != 1)
+    {
+      fprintf(stderr, "Invalid number of arguments. Program only takes "
+                      "one non-option argument (rom_filepath).\n");
       exit(EXIT_FAILURE);
     }
 
@@ -23,7 +54,7 @@ main(int argc, char *argv[])
   uint16_t load_address = 0x0000;
 
   // Load ROM into memory
-  if (!cpu_load_file(&cpu, argv[1], load_address))
+  if (!cpu_load_file(&cpu, argv[optind], load_address))
     {
       fprintf(stderr, "Failed to load ROM\n");
       exit(EXIT_FAILURE);
@@ -31,17 +62,34 @@ main(int argc, char *argv[])
 
   while (true)
     {
-
       // 1 Fetch, decode, and execute next instruction
       // fetch_decode_execute(&cpu)
 
       // fetch and execute next instruction
       uint8_t next_instruction = cpu_read_mem(&cpu, cpu.pc);
+      if (pflag)
+        {
+          print_instruction(next_instruction);
+        }
+      if (dflag)
+        {
+          printf("PRE-INSTRUCTION  ");
+          print_state(&cpu);
+          print_flags(cpu.flags);
+          printf("\n");
+        }
       if (execute_instruction(&cpu, next_instruction) < 0)
         {
           fprintf(stderr,
                   "Unimplemented opcode encountered. Exiting program.\n");
           exit(EXIT_FAILURE);
+        }
+      if (dflag)
+        {
+          printf("POST-INSTRUCTION ");
+          print_state(&cpu);
+          print_flags(cpu.flags);
+          printf("\n");
         }
 
       // 2 Handle interrupts

--- a/shell.c
+++ b/shell.c
@@ -14,29 +14,29 @@ main(int argc, char *argv[])
   int opt;
 
   while ((opt = getopt(argc, argv, "pd")) != -1)
-  {
-    switch (opt)
     {
-      case 'p':
-        pflag = 1;
-        break;
-      case 'd':
-        dflag = 1;
-        break;
-      case '?':
-        if (isprint(optopt))
-          {
-            fprintf(stderr, "Unknown option '-%c'.\n", optopt);
-          }
-        else
-          {
-            fprintf(stderr, "Unknown option character '\\x%x.\n", optopt);
-          }
-        exit(EXIT_FAILURE);
-      default:
-        abort();
+      switch (opt)
+        {
+        case 'p':
+          pflag = 1;
+          break;
+        case 'd':
+          dflag = 1;
+          break;
+        case '?':
+          if (isprint(optopt))
+            {
+              fprintf(stderr, "Unknown option '-%c'.\n", optopt);
+            }
+          else
+            {
+              fprintf(stderr, "Unknown option character '\\x%x.\n", optopt);
+            }
+          exit(EXIT_FAILURE);
+        default:
+          abort();
+        }
     }
-  }
 
   // Only accept one non-option argument
   if ((argc - optind) != 1)


### PR DESCRIPTION
### Flags added
- extensible flag parsing added to shell.c (https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html)
  - flags can be added before or after filepath argument
  - error handling for unrecognized flags
  - error handling for incorrect number of non-flag arguments refactored to account for flags
- two new flags added: -p and -d
  - p prints the current instruction being executed to stdout
  - d prints the pre and post instruction cpu state to stdout
 
### Printing refactor
- removed print_instruction and print_state from execute_instructions function
- printing instructions and/or printing state now occurs in the main function of shell.c
- p and d flags determine which of the above functions are called
- print_state now prints hexes as "0x%02x" instead of "0x%x" to provide consistent 1 byte formatting of all hex values.

### Printing CPU flags
- CPU flags now print as human readable (FLAGS z: 0 s: 0 p: 0 cy: 0 ac: 0 ) rather than 1 byte hex values
- CPU flags printed in new function print_flags and removed from print_state

### README Update
- README updated to provide instruction on using flags when executing program