### PR TITLE
Interrupt Implementation

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -4,6 +4,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define BYTE 8
+#define UPPER_8_BIT_MASK 0xFF00
+#define LOWER_8_BIT_MASK 0x00FF
+#define RST_RANGE 7
+
 // Execute Instruction
 int
 execute_instruction(i8080 *cpu, uint8_t opcode)
@@ -673,18 +678,18 @@ print_flags(uint8_t flags)
 int
 handle_interrupt(i8080 *cpu, uint8_t rst_instruction)
 {
-  if (rst_instruction > 0x07)
+  if (rst_instruction > RST_RANGE)
     {
       fprintf(stderr, "Invalid restart instruction %u", rst_instruction);
       return -1;
     }
 
   // get address for interrupt subroutine
-  uint16_t subroutine_address = 0x08 * rst_instruction;
+  uint16_t subroutine_address = BYTE * rst_instruction;
 
   // push program counter to stack
-  cpu_write_mem(cpu, cpu->sp - 1, (uint8_t)((cpu->pc & 0xFF00) >> 8));
-  cpu_write_mem(cpu, cpu->sp - 2, (uint8_t)(cpu->pc & 0x00FF));
+  cpu_write_mem(cpu, cpu->sp - 1, (uint8_t)((cpu->pc & UPPER_8_BIT_MASK) >> BYTE));
+  cpu_write_mem(cpu, cpu->sp - 2, (uint8_t)(cpu->pc & LOWER_8_BIT_MASK));
   cpu->sp -= 2;
 
   // set program counter to start of the interrupt subroutine

--- a/emulator.c
+++ b/emulator.c
@@ -684,6 +684,11 @@ handle_interrupt(i8080 *cpu, uint8_t rst_instruction)
       return -1;
     }
 
+  if (cpu->interrupt_enabled == false)
+    {
+      return 0;
+    }
+
   // get address for interrupt subroutine
   uint16_t subroutine_address = BYTE * rst_instruction;
 

--- a/emulator.c
+++ b/emulator.c
@@ -688,7 +688,8 @@ handle_interrupt(i8080 *cpu, uint8_t rst_instruction)
   uint16_t subroutine_address = BYTE * rst_instruction;
 
   // push program counter to stack
-  cpu_write_mem(cpu, cpu->sp - 1, (uint8_t)((cpu->pc & UPPER_8_BIT_MASK) >> BYTE));
+  cpu_write_mem(cpu, cpu->sp - 1,
+                (uint8_t)((cpu->pc & UPPER_8_BIT_MASK) >> BYTE));
   cpu_write_mem(cpu, cpu->sp - 2, (uint8_t)(cpu->pc & LOWER_8_BIT_MASK));
   cpu->sp -= 2;
 

--- a/emulator.h
+++ b/emulator.h
@@ -83,3 +83,8 @@ Helper functions to print instruction and cpu state
 void print_instruction(uint8_t opcode);
 void print_state(i8080 *cpu);
 void print_flags(uint8_t flags);
+
+/*
+Interrupt functions
+*/
+int handle_interrupt(i8080 *cpu, uint8_t rst_instruction);

--- a/tests.c
+++ b/tests.c
@@ -1181,16 +1181,16 @@ test_handle_interrupt(void) // NOLINT
 {
   i8080 cpu;
   cpu_init(&cpu);
-  cpu.pc = 0xAABB;                                      // NOLINT
-  cpu.sp = 0xFFFF;                                      // NOLINT
+  cpu.pc = 0xAABB; // NOLINT
+  cpu.sp = 0xFFFF; // NOLINT
 
   int interrupt_handled = handle_interrupt(&cpu, 0x01); // NOLINT
 
   CU_ASSERT(interrupt_handled == 0);
-  CU_ASSERT(cpu.pc == 0x0008);                          // NOLINT
-  CU_ASSERT(cpu.sp == 0xFFFD);                          // NOLINT
-  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp) == 0xBB);        // NOLINT
-  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp + 1) == 0xAA);    // NOLINT
+  CU_ASSERT(cpu.pc == 0x0008);                       // NOLINT
+  CU_ASSERT(cpu.sp == 0xFFFD);                       // NOLINT
+  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp) == 0xBB);     // NOLINT
+  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp + 1) == 0xAA); // NOLINT
 
   // clean up
   cpu_write_mem(&cpu, 0xFFFE, 0x00); // NOLINT
@@ -1202,14 +1202,14 @@ test_handle_interrupt_invalid_rst(void) // NOLINT
 {
   i8080 cpu;
   cpu_init(&cpu);
-  cpu.pc = 0xAABB;                                      // NOLINT
-  cpu.sp = 0xFFFF;                                      // NOLINT
+  cpu.pc = 0xAABB; // NOLINT
+  cpu.sp = 0xFFFF; // NOLINT
 
   int interrupt_handled = handle_interrupt(&cpu, 0x08); // NOLINT
 
   CU_ASSERT(interrupt_handled == -1);
-  CU_ASSERT(cpu.pc == 0xAABB);                          // NOLINT
-  CU_ASSERT(cpu.sp == 0xFFFF);                          // NOLINT
+  CU_ASSERT(cpu.pc == 0xAABB); // NOLINT
+  CU_ASSERT(cpu.sp == 0xFFFF); // NOLINT
 }
 
 int

--- a/tests.c
+++ b/tests.c
@@ -1181,6 +1181,7 @@ test_handle_interrupt(void) // NOLINT
 {
   i8080 cpu;
   cpu_init(&cpu);
+  cpu.interrupt_enabled = true;
   cpu.pc = 0xAABB; // NOLINT
   cpu.sp = 0xFFFF; // NOLINT
 
@@ -1189,6 +1190,7 @@ test_handle_interrupt(void) // NOLINT
   CU_ASSERT(interrupt_handled == 0);
   CU_ASSERT(cpu.pc == 0x0008);                       // NOLINT
   CU_ASSERT(cpu.sp == 0xFFFD);                       // NOLINT
+  CU_ASSERT(cpu.interrupt_enabled == false);         // NOLINT
   CU_ASSERT(cpu_read_mem(&cpu, cpu.sp) == 0xBB);     // NOLINT
   CU_ASSERT(cpu_read_mem(&cpu, cpu.sp + 1) == 0xAA); // NOLINT
 
@@ -1202,12 +1204,30 @@ test_handle_interrupt_invalid_rst(void) // NOLINT
 {
   i8080 cpu;
   cpu_init(&cpu);
+  cpu.interrupt_enabled = true;
   cpu.pc = 0xAABB; // NOLINT
   cpu.sp = 0xFFFF; // NOLINT
 
   int interrupt_handled = handle_interrupt(&cpu, 0x08); // NOLINT
 
   CU_ASSERT(interrupt_handled == -1);
+  CU_ASSERT(cpu.interrupt_enabled == true);
+  CU_ASSERT(cpu.pc == 0xAABB); // NOLINT
+  CU_ASSERT(cpu.sp == 0xFFFF); // NOLINT
+}
+
+void
+test_handle_interrupt_interrupts_disabled(void) // NOLINT
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+  cpu.pc = 0xAABB; // NOLINT
+  cpu.sp = 0xFFFF; // NOLINT
+
+  int interrupt_handled = handle_interrupt(&cpu, 0x08); // NOLINT
+
+  CU_ASSERT(interrupt_handled == 0);
+  CU_ASSERT(cpu.interrupt_enabled == false);
   CU_ASSERT(cpu.pc == 0xAABB); // NOLINT
   CU_ASSERT(cpu.sp == 0xFFFF); // NOLINT
 }
@@ -1385,7 +1405,16 @@ main(void)
                          test_opcode_0xc3))
       || (NULL
           == CU_add_test(pSuite, "test of test_opcode_0xa7()",
-                         test_opcode_0xa7)))
+                         test_opcode_0xa7))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_handle_interrupt()",
+                         test_handle_interrupt))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_handle_interrupt_invalid_rst()",
+                         test_handle_interrupt_invalid_rst))
+      || (NULL
+          == CU_add_test(pSuite, "test_handle_interrupt_interrupts_disabled()",
+                         test_handle_interrupt_interrupts_disabled)))
     {
       CU_cleanup_registry();
       return CU_get_error();

--- a/tests.c
+++ b/tests.c
@@ -1176,6 +1176,42 @@ test_opcode_0xfe(void) // NOLINT
   cpu_write_mem(&cpu, 0x0005, 0x00); // NOLINT
 }
 
+void
+test_handle_interrupt(void) // NOLINT
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+  cpu.pc = 0xAABB;                                    // NOLINT
+  cpu.sp = 0xFFFF;                                    // NOLINT
+
+  int interrupt_handled = handle_interrupt(&cpu, 0x01);
+
+  CU_ASSERT(interrupt_handled == 0);
+  CU_ASSERT(cpu.pc == 0x0008);                        // NOLINT
+  CU_ASSERT(cpu.sp == 0xFFFD);                        // NOLINT
+  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp) == 0xBB);      // NOLINT
+  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp + 1) == 0xAA);  // NOLINT
+
+  // clean up
+  cpu_write_mem(&cpu, 0xFFFE, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0xFFFD, 0x00); // NOLINT
+}
+
+void
+test_handle_interrupt_invalid_rst(void) // NOLINT
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+  cpu.pc = 0xAABB;                                    // NOLINT
+  cpu.sp = 0xFFFF;                                    // NOLINT
+
+  int interrupt_handled = handle_interrupt(&cpu, 0x08);
+
+  CU_ASSERT(interrupt_handled == -1);
+  CU_ASSERT(cpu.pc == 0xAABB);                        // NOLINT
+  CU_ASSERT(cpu.sp == 0xFFFF);                        // NOLINT
+}
+
 int
 main(void)
 {

--- a/tests.c
+++ b/tests.c
@@ -1224,7 +1224,7 @@ test_handle_interrupt_interrupts_disabled(void) // NOLINT
   cpu.pc = 0xAABB; // NOLINT
   cpu.sp = 0xFFFF; // NOLINT
 
-  int interrupt_handled = handle_interrupt(&cpu, 0x08); // NOLINT
+  int interrupt_handled = handle_interrupt(&cpu, 0x01); // NOLINT
 
   CU_ASSERT(interrupt_handled == 0);
   CU_ASSERT(cpu.interrupt_enabled == false);

--- a/tests.c
+++ b/tests.c
@@ -1181,16 +1181,16 @@ test_handle_interrupt(void) // NOLINT
 {
   i8080 cpu;
   cpu_init(&cpu);
-  cpu.pc = 0xAABB;                                    // NOLINT
-  cpu.sp = 0xFFFF;                                    // NOLINT
+  cpu.pc = 0xAABB;                                      // NOLINT
+  cpu.sp = 0xFFFF;                                      // NOLINT
 
-  int interrupt_handled = handle_interrupt(&cpu, 0x01);
+  int interrupt_handled = handle_interrupt(&cpu, 0x01); // NOLINT
 
   CU_ASSERT(interrupt_handled == 0);
-  CU_ASSERT(cpu.pc == 0x0008);                        // NOLINT
-  CU_ASSERT(cpu.sp == 0xFFFD);                        // NOLINT
-  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp) == 0xBB);      // NOLINT
-  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp + 1) == 0xAA);  // NOLINT
+  CU_ASSERT(cpu.pc == 0x0008);                          // NOLINT
+  CU_ASSERT(cpu.sp == 0xFFFD);                          // NOLINT
+  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp) == 0xBB);        // NOLINT
+  CU_ASSERT(cpu_read_mem(&cpu, cpu.sp + 1) == 0xAA);    // NOLINT
 
   // clean up
   cpu_write_mem(&cpu, 0xFFFE, 0x00); // NOLINT
@@ -1202,14 +1202,14 @@ test_handle_interrupt_invalid_rst(void) // NOLINT
 {
   i8080 cpu;
   cpu_init(&cpu);
-  cpu.pc = 0xAABB;                                    // NOLINT
-  cpu.sp = 0xFFFF;                                    // NOLINT
+  cpu.pc = 0xAABB;                                      // NOLINT
+  cpu.sp = 0xFFFF;                                      // NOLINT
 
-  int interrupt_handled = handle_interrupt(&cpu, 0x08);
+  int interrupt_handled = handle_interrupt(&cpu, 0x08); // NOLINT
 
   CU_ASSERT(interrupt_handled == -1);
-  CU_ASSERT(cpu.pc == 0xAABB);                        // NOLINT
-  CU_ASSERT(cpu.sp == 0xFFFF);                        // NOLINT
+  CU_ASSERT(cpu.pc == 0xAABB);                          // NOLINT
+  CU_ASSERT(cpu.sp == 0xFFFF);                          // NOLINT
 }
 
 int


### PR DESCRIPTION
### Interrupts
Added the handle_interrupt function to emulator.c. If interrupts are currently enabled, it takes a valid RST instruction (0-7), pushes the current program counter to the stack, and then sets the program counter to the start of the interrupt subroutine as defined by the RST value. It also disables interrupts upon termination. On a success handle_interrupt returns 0, on a failure returns -1.

Unit tests added for both a successful handle_interrupt call, a failed call (invalid RST instruction passed) and a call when interrupts are disabled.