### PR TITLE
Opcodes 0xda and 0xdb

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -409,10 +409,10 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu_read_mem(cpu, cpu->pc + 2);
         address = (address << 8) | cpu_read_mem(cpu, cpu->pc + 1); // NOLINT
         if ((cpu->flags & FLAG_CY) == FLAG_CY) // if CY set JUMP
-        {
-          cpu->pc = address;
-          return 0;
-        }
+          {
+            cpu->pc = address;
+            return 0;
+          }
         cpu->pc += 2;
         break;
       }

--- a/emulator.c
+++ b/emulator.c
@@ -407,7 +407,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
     case 0xda: // NOLINT
       {        // JC ADR
         uint16_t address = cpu_read_mem(cpu, cpu->pc + 2);
-        address = (address << 8) | cpu_read_mem(cpu, cpu->pc + 1); // NOLINT
+        address = (address << BYTE) | cpu_read_mem(cpu, cpu->pc + 1);
         if ((cpu->flags & FLAG_CY) == FLAG_CY) // if CY set JUMP
           {
             cpu->pc = address;
@@ -417,7 +417,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         break;
       }
     case 0xdb: // NOLINT
-      {        // JC
+      {        // IN D8
         uint8_t port = cpu_read_mem(cpu, cpu->pc + 1);
         printf("%u", port);
         cpu->pc += 1;

--- a/emulator.c
+++ b/emulator.c
@@ -404,8 +404,20 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 2;
         break;
       }
+    case 0xda: // NOLINT
+      {        // JC ADR
+        uint16_t address = cpu_read_mem(cpu, cpu->pc + 2);
+        address = (address << 8) | cpu_read_mem(cpu, cpu->pc + 1); // NOLINT
+        if ((cpu->flags & FLAG_CY) == FLAG_CY) // if CY set JUMP
+        {
+          cpu->pc = address;
+          return 0;
+        }
+        cpu->pc += 2;
+        break;
+      }
     case 0xdb: // NOLINT
-      {        // IN D8
+      {        // JC
         uint8_t port = cpu_read_mem(cpu, cpu->pc + 1);
         printf("%u", port);
         cpu->pc += 1;

--- a/emulator.c
+++ b/emulator.c
@@ -404,6 +404,13 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 2;
         break;
       }
+    case 0xdb: // NOLINT
+      {        // IN D8
+        uint8_t port = cpu_read_mem(cpu, cpu->pc + 1);
+        printf("%u", port);
+        cpu->pc += 1;
+        break;
+      }
     case 0xe1: // NOLINT
       {        // POP H
         cpu->l = cpu_read_mem(cpu, cpu->sp);

--- a/tests.c
+++ b/tests.c
@@ -933,6 +933,37 @@ test_opcode_0xd1(void) // NOLINT
 }
 
 void
+test_opcode_0xda(void) // NOLINT
+{
+  // JMP CY
+  i8080 cpu;
+  cpu_init(&cpu);
+
+  cpu.pc = 0x1234;                       // NOLINT
+  cpu.flags = 0;                         // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 1, 0xBB); // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 2, 0xAA); // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 4, 0xDD); // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 5, 0xCC); // NOLINT
+
+  int code_found = execute_instruction(&cpu, 0xda); // NOLINT
+
+  CU_ASSERT(code_found == 0);
+  CU_ASSERT_EQUAL(cpu.pc, 0x1237); // NOLINT
+
+  cpu.flags |= FLAG_CY;
+  code_found = execute_instruction(&cpu, 0xda); // NOLINT
+
+  CU_ASSERT(code_found == 0);
+  CU_ASSERT_EQUAL(cpu.pc, 0xCCDD); // NOLINT
+
+  cpu_write_mem(&cpu, 0x1235, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x1236, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x1237, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x1238, 0x00); // NOLINT
+}
+
+void
 test_opcode_0xe5(void) // NOLINT
 {                      // PUSH H
 
@@ -1386,6 +1417,9 @@ main(void)
       || (NULL
           == CU_add_test(pSuite, "test of test_opcode_0xd5()",
                          test_opcode_0xd5))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0xda()",
+                         test_opcode_0xda))
       || (NULL
           == CU_add_test(pSuite, "test of test_opcode_0xe5()",
                          test_opcode_0xe5))

--- a/tests.c
+++ b/tests.c
@@ -479,6 +479,7 @@ test_opcode_0xdb(void)
   int code_found = execute_instruction(&cpu, 0xdb); // NOLINT
   CU_ASSERT(code_found == 0);
   CU_ASSERT(cpu.pc == initial_pc + 2);
+  // TODO: check contents of A register to see if byte received from port 1
 
   cpu_write_mem(&cpu, 0x0001, 0x00);
 }

--- a/tests.c
+++ b/tests.c
@@ -468,6 +468,22 @@ test_opcode_0xd3(void)
 }
 
 void
+test_opcode_0xdb(void)
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+  uint16_t initial_pc = cpu.pc;
+  cpu.a = 0x50; // NOLINT
+  cpu_write_mem(&cpu, 0x0001, 0x01);
+
+  int code_found = execute_instruction(&cpu, 0xdb); // NOLINT
+  CU_ASSERT(code_found == 0);
+  CU_ASSERT(cpu.pc == initial_pc + 2);
+
+  cpu_write_mem(&cpu, 0x0001, 0x00);
+}
+
+void
 test_opcode_0x7c(void)
 {
   i8080 cpu;
@@ -1304,6 +1320,9 @@ main(void)
       || (NULL
           == CU_add_test(pSuite, "test of test_opcode_0xd3()",
                          test_opcode_0xd3))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0xdb()",
+                         test_opcode_0xdb))
       || (NULL
           == CU_add_test(pSuite, "test of test_opcode_0xe6()",
                          test_opcode_0xe6))


### PR DESCRIPTION
### 0xda - JC ADR
If CY flag is set, then sets program counter to 16-bit address passed as argument. Otherwise increments program counter by 3 to move to next opcode. Unit test added that tests both when CY flag is set and unset.

### 0xdb - IN d8
Partial implementation. Takes d8 and assigns to port device #. Currently prints port number to stdout before incrementing pc by 2 to move to the next opcode. Eventually it should set the contents of the A register to the next byte in the given port device number.