### PR TITLE
implement 0xca opcode + tests

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -498,7 +498,6 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       }
     }
   cpu->pc += 1;
-  printf("cpu->pc: %x\n", cpu->pc);
   return 0;
 }
 

--- a/emulator.c
+++ b/emulator.c
@@ -369,6 +369,19 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->pc = address;
         return 0;
       }
+    case 0xca: // NOLINT
+      {        // JZ
+        if (is_zero_flag_set(cpu))
+          {
+            uint16_t address = cpu_read_mem(cpu, cpu->pc + 2); // NOLINT
+            address = address << 8;                            // NOLINT
+            address += cpu_read_mem(cpu, cpu->pc + 1);
+            cpu->pc = address;
+            return 0;
+          }
+        cpu->pc += 2; // NOLINT
+        break;
+      }
     case 0xcd:                                                   // NOLINT
       {                                                          // CALL ADDR
         cpu_write_mem(cpu, cpu->sp - 1, ((cpu->pc + 3) >> 8));   // NOLINT
@@ -485,6 +498,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       }
     }
   cpu->pc += 1;
+  printf("cpu->pc: %x\n", cpu->pc);
   return 0;
 }
 
@@ -635,6 +649,12 @@ bool
 is_sign_flag_set(i8080 *cpu)
 {
   return (cpu->flags & FLAG_S) != 0;
+}
+
+bool
+is_zero_flag_set(i8080 *cpu)
+{
+  return (cpu->flags & FLAG_Z) == 0;
 }
 
 void

--- a/emulator.c
+++ b/emulator.c
@@ -582,7 +582,7 @@ update_aux_carry_flag(i8080 *cpu, uint8_t a, uint8_t b)
   // then adds nibbles to test for AC
   uint16_t result = (a & 0x0F) + (b & 0x0F); // NOLINT
   if (result & 0x10)                         // NOLINT
-    { // Check if carry from bit 3 to bit 4 existss
+    { // Check if carry from bit 3 to bit 4 exists
       cpu->flags |= FLAG_AC;
     }
   else
@@ -654,7 +654,7 @@ is_sign_flag_set(i8080 *cpu)
 bool
 is_zero_flag_set(i8080 *cpu)
 {
-  return (cpu->flags & FLAG_Z) == 0;
+  return (cpu->flags & FLAG_Z) != 0;
 }
 
 void

--- a/emulator.h
+++ b/emulator.h
@@ -67,6 +67,8 @@ void update_zero_flag(i8080 *cpu, uint8_t result);
 // Sign Flag
 void update_sign_flag(i8080 *cpu, uint8_t result);
 bool is_sign_flag_set(i8080 *cpu);
+bool is_zero_flag_set(i8080 *cpu);
+
 // Carry Flag
 void update_carry_flag(i8080 *cpu, bool carry_occurred);
 /*

--- a/tests.c
+++ b/tests.c
@@ -475,8 +475,10 @@ test_opcode_0xca(void)
   CU_ASSERT(cpu.pc == 0xa93a); // NOLINT
 
   // cleanup
-  cpu_write_mem(&cpu, 0x0001, 0x00); // NOLINT
-  cpu_write_mem(&cpu, 0x0002, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x4342, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x4343, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x5442, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x5443, 0x00); // NOLINT
 }
 
 void

--- a/tests.c
+++ b/tests.c
@@ -457,19 +457,19 @@ test_opcode_0xca(void)
   cpu_init(&cpu);
 
   // case where zero flag not set
-  cpu.pc = 0x4341;                       // NOLINT
-  cpu_write_mem(&cpu, cpu.pc + 1, 0x28); // NOLINT
-  cpu_write_mem(&cpu, cpu.pc + 2, 0xb7); // NOLINT
-  update_zero_flag(&cpu, 0x00);
+  cpu.pc = 0x4341;                                  // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 1, 0x28);            // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 2, 0xb7);            // NOLINT
+  update_zero_flag(&cpu, 1);                        // had a remainder
   int code_found = execute_instruction(&cpu, 0xca); // NOLINT
   CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 0x4344); // NOLINT
 
   // case where zero flag set
-  cpu.pc = 0x5441;                       // NOLINT
-  cpu_write_mem(&cpu, cpu.pc + 1, 0x3a); // NOLINT
-  cpu_write_mem(&cpu, cpu.pc + 2, 0xa9); // NOLINT
-  update_zero_flag(&cpu, true);
+  cpu.pc = 0x5441;                              // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 1, 0x3a);        // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 2, 0xa9);        // NOLINT
+  update_zero_flag(&cpu, 0);                    // no remainder
   code_found = execute_instruction(&cpu, 0xca); // NOLINT
   CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 0xa93a); // NOLINT

--- a/tests.c
+++ b/tests.c
@@ -451,6 +451,35 @@ test_opcode_0xc6(void)
 }
 
 void
+test_opcode_0xca(void)
+{ // JZ
+  i8080 cpu;
+  cpu_init(&cpu);
+
+  // case where zero flag not set
+  cpu.pc = 0x4341;                       // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 1, 0x28); // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 2, 0xb7); // NOLINT
+  update_zero_flag(&cpu, 0x00);
+  int code_found = execute_instruction(&cpu, 0xca); // NOLINT
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT(cpu.pc == 0x4344); // NOLINT
+
+  // case where zero flag set
+  cpu.pc = 0x5441;                       // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 1, 0x3a); // NOLINT
+  cpu_write_mem(&cpu, cpu.pc + 2, 0xa9); // NOLINT
+  update_zero_flag(&cpu, true);
+  code_found = execute_instruction(&cpu, 0xca); // NOLINT
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT(cpu.pc == 0xa93a); // NOLINT
+
+  // cleanup
+  cpu_write_mem(&cpu, 0x0001, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x0002, 0x00); // NOLINT
+}
+
+void
 test_opcode_0xd3(void)
 {
   i8080 cpu;
@@ -1397,6 +1426,9 @@ main(void)
       || (NULL
           == CU_add_test(pSuite, "test of test_opcode_0xf1()",
                          test_opcode_0xf1))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0xca()",
+                         test_opcode_0xca))
       || (NULL
           == CU_add_test(pSuite, "test of test_opcode_0xcd()",
                          test_opcode_0xcd))


### PR DESCRIPTION
0xca - JZ ADR

If Z flag is set, then sets program counter to 16-bit address passed as argument. Otherwise increments program counter by 3 to move to next opcode. Unit test added that tests both when Z flag is set and unset.