### PR TITLE
Adding timing implementation including interrupts, updated unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt install libcunit1 libcunit1-doc libcunit1-dev 
+      - run: sudo apt install libcunit1 libcunit1-doc libcunit1-dev libsdl2-dev
       - uses: cpp-linter/cpp-linter-action@v2
         id: linter
         env:
@@ -31,6 +31,8 @@ jobs:
 # install dependencies - TODO
     - name: install cunit
       run: sudo apt install libcunit1 libcunit1-doc libcunit1-dev
+    - name: install sdl
+      run: sudo apt install libsdl2-dev
 
 # clean
     - name: cleaning up

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ CC = clang
 # compiler flags
 CFLAGS = -g -W -Wall -Wextra -pedantic `pkg-config --cflags --libs sdl2`
 
-# linker flags LINKER_FLAGS = -lSDL2
-
 # targets to build
 TARGETS = disassembler_8080 shell
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 CC = clang
 
 # compiler flags
-CFLAGS = -g -W -Wall -Wextra -pedantic
+CFLAGS = -g -W -Wall -Wextra -pedantic `pkg-config --cflags --libs sdl2`
+
+# linker flags LINKER_FLAGS = -lSDL2
 
 # targets to build
 TARGETS = disassembler_8080 shell

--- a/emulator.c
+++ b/emulator.c
@@ -379,6 +379,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu_read_mem(cpu, cpu->pc + 2);
         address = (address << 8) | cpu_read_mem(cpu, cpu->pc + 1); // NOLINT
         cpu->pc = address;
+        // NOLINTNEXTLINE
         return 10; // no PC increment due to JMP, return num cycles
       }
     case 0xc5: // NOLINT
@@ -413,6 +414,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             address += (cpu_read_mem(cpu, cpu->sp + 1) << 8); // NOLINT
             cpu->sp += 2;
             cpu->pc = address;
+            // NOLINTNEXTLINE
             return 11; // return num cycles
           }
         num_cycles = 5; // NOLINT
@@ -425,6 +427,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         address += (cpu_read_mem(cpu, cpu->sp + 1) << 8); // NOLINT
         cpu->sp += 2;
         cpu->pc = address;
+        // NOLINTNEXTLINE
         return 10; // return num cycles
       }
     case 0xca: // NOLINT
@@ -435,6 +438,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             address = address << 8;                            // NOLINT
             address += cpu_read_mem(cpu, cpu->pc + 1);
             cpu->pc = address;
+            // NOLINTNEXTLINE
             return 10; // return num cycles
           }
         cpu->pc += 2;    // NOLINT
@@ -449,6 +453,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 2;
         cpu->pc = (cpu_read_mem(cpu, cpu->pc + 2) << 8) // NOLINT
                   | (cpu_read_mem(cpu, cpu->pc + 1));
+        // NOLINTNEXTLINE
         return 17; // return num cycles
       }
     case 0xd1: // NOLINT
@@ -486,6 +491,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         if ((cpu->flags & FLAG_CY) == FLAG_CY) // if CY set JUMP
           {
             cpu->pc = address;
+            // NOLINTNEXTLINE
             return 10; // return cycle number
           }
         cpu->pc += 2;

--- a/emulator.c
+++ b/emulator.c
@@ -236,7 +236,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu_write_mem(cpu, address, cpu_read_mem(cpu, cpu->pc + 1));
 
         cpu->pc += 1;
-        num_cycles = 10;
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0x3a: // NOLINT
@@ -245,14 +245,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         addr = (addr << 8) + cpu_read_mem(cpu, cpu->pc + 1); // NOLINT
         cpu->a = cpu_read_mem(cpu, addr);
         cpu->pc += 2;
-        num_cycles = 13;
+        num_cycles = 13; // NOLINT
         break;
       }
     case 0x3e: // NOLINT
       {
         cpu->a = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->pc += 1;
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0x56: // NOLINT
@@ -261,7 +261,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu->l;
         address += (cpu->h << 8); // NOLINT
         cpu->d = cpu_read_mem(cpu, address);
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0x5e: // NOLINT
@@ -270,7 +270,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = (cpu->h << 8) | cpu->l; // NOLINT
 
         cpu->e = cpu_read_mem(cpu, address);
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0x66: // NOLINT
@@ -278,13 +278,13 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t addr = cpu->h;
         addr = (addr << 8) + cpu->l; // NOLINT
         cpu->h = cpu_read_mem(cpu, addr);
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0x6f: // NOLINT
       {
         cpu->l = cpu->a;
-        num_cycles = 5;
+        num_cycles = 5; // NOLINT
         break;
       }
     case 0x77: // NOLINT
@@ -292,25 +292,25 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu->l;
         address += (cpu->h << 8); // NOLINT
         cpu_write_mem(cpu, address, cpu->a);
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0x7a: // NOLINT
       {        // MOV A,D
         cpu->a = cpu->d;
-        num_cycles = 5;
+        num_cycles = 5; // NOLINT
         break;
       }
     case 0x7b: // NOLINT
       {        // MOV A,E
         cpu->a = cpu->e;
-        num_cycles = 5;
+        num_cycles = 5; // NOLINT
         break;
       }
     case 0x7c: // NOLINT
       {
         cpu->a = cpu->h;
-        num_cycles = 5;
+        num_cycles = 5; // NOLINT
         break;
       }
     case 0x7e: // NOLINT
@@ -318,7 +318,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu->l;
         address += (cpu->h << 8); // NOLINT
         cpu->a = cpu_read_mem(cpu, address);
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0xa7: // NOLINT
@@ -331,7 +331,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_parity_flag(cpu, cpu->a);
         update_aux_carry_flag(cpu, temp, cpu->a);
         update_carry_flag(cpu, false);
-        num_cycles = 4;
+        num_cycles = 4; // NOLINT
 
         break;
       }
@@ -345,7 +345,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_aux_carry_flag(cpu, result, 0xFF); // NOLINT
 
         cpu->a = result;
-        num_cycles = 4;
+        num_cycles = 4; // NOLINT
 
         break;
       }
@@ -353,8 +353,8 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       {
         cpu->c = cpu_read_mem(cpu, cpu->sp);
         cpu->b = cpu_read_mem(cpu, cpu->sp + 1);
-        cpu->sp += 2;
-        num_cycles = 10;
+        cpu->sp += 2;    // NOLINT
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0xc2: // NOLINT
@@ -366,10 +366,11 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             // returns rather than breaks to avoid pc increment at end of
             // function
             cpu->pc = address;
+            // NOLINTNEXTLINE
             return 10; // return cycle number
           }
         cpu->pc += 2;
-        num_cycles = 10;
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0xc3: // NOLINT
@@ -386,7 +387,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 1;
         cpu_write_mem(cpu, cpu->sp - 1, cpu->c);
         cpu->sp -= 1;
-        num_cycles = 11;
+        num_cycles = 11; // NOLINT
         break;
       }
     case 0xc6: // NOLINT
@@ -401,7 +402,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_aux_carry_flag(cpu, cpu->a, immediate);
         cpu->a = (uint8_t)answer;
         cpu->pc += 1;
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0xc8:                               // NOLINT

--- a/emulator.c
+++ b/emulator.c
@@ -16,17 +16,17 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
   int num_cycles = 0;
   switch (opcode)
     {
-    case 0x00: // NOLINT
-      {        // NOP
-        num_cycles = 4;
+    case 0x00:          // NOLINT
+      {                 // NOP
+        num_cycles = 4; // NOLINT
         break;
       }
     case 0x01: // NOLINT
       {        // LXI B
         cpu->c = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->b = cpu_read_mem(cpu, cpu->pc + 2);
-        cpu->pc += 2;
-        num_cycles = 10;
+        cpu->pc += 2;    // NOLINT
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0x05: // NOLINT
@@ -37,7 +37,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_sign_flag(cpu, cpu->b);
         update_parity_flag(cpu, cpu->b);
         update_aux_carry_flag(cpu, cpu->b, 0xFF); // NOLINT
-        num_cycles = 5;
+        num_cycles = 5;                           // NOLINT
 
         break;
       }
@@ -45,7 +45,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       {        // MVI B, mem8
         cpu->b = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->pc += 1;
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0x09: // NOLINT
@@ -57,7 +57,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_carry_flag(cpu, result > 0xFFFF); // NOLINT
         cpu->h = (result & 0xff00) >> 8;         // NOLINT
         cpu->l = (result & 0xff);                // NOLINT
-        num_cycles = 10;
+        num_cycles = 10;                         // NOLINT
         break;
       }
     case 0x0d: // NOLINT
@@ -68,14 +68,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_parity_flag(cpu, result);
         update_aux_carry_flag(cpu, cpu->c, 0xFF); // NOLINT
         cpu->c = result;
-        num_cycles = 5;
+        num_cycles = 5; // NOLINT
         break;
       }
     case 0x0e: // NOLINT
       {        // MVI C, D8
         cpu->c = cpu_read_mem(cpu, (cpu->pc + 1));
         cpu->pc += 1;
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0x0f: // NOLINT
@@ -99,15 +99,15 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
           {
             update_carry_flag(cpu, false);
           }
-        num_cycles = 4;
+        num_cycles = 4; // NOLINT
         break;
       }
     case 0x11: // NOLINT
       {
         cpu->e = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->d = cpu_read_mem(cpu, cpu->pc + 2);
-        cpu->pc += 2;
-        num_cycles = 10;
+        cpu->pc += 2;    // NOLINT
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0x13: // NOLINT
@@ -118,7 +118,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             cpu->d += 1;
           }
         break;
-        num_cycles = 5;
+        num_cycles = 5; // NOLINT
       }
     case 0x19: // NOLINT
       {        // DAD D
@@ -134,7 +134,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->h = sum >> 8;                      // NOLINT
         cpu->l = sum & 0xFF;                    // NOLINT
         update_carry_flag(cpu, (sum > 0xFFFF)); // NOLINT
-        num_cycles = 10;
+        num_cycles = 10;                        // NOLINT
 
         break;
       }
@@ -150,7 +150,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
 
         // put value in a
         cpu->a = val;
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0x21: // NOLINT
@@ -158,8 +158,8 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       {
         cpu->l = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->h = cpu_read_mem(cpu, cpu->pc + 2);
-        cpu->pc += 2;
-        num_cycles = 10;
+        cpu->pc += 2;    // NOLINT
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0x23: // NOLINT
@@ -169,14 +169,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
           {
             cpu->h += 1;
           }
-        num_cycles = 5;
+        num_cycles = 5; // NOLINT
         break;
       }
     case 0x26: // NOLINT
       {        // MVI H, D8
         cpu->h = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->pc += 1;
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0x29: // NOLINT
@@ -414,7 +414,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             cpu->pc = address;
             return 11; // return num cycles
           }
-        num_cycles = 5;
+        num_cycles = 5; // NOLINT
         break;
       }
     case 0xc9: // NOLINT
@@ -436,8 +436,8 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             cpu->pc = address;
             return 10; // return num cycles
           }
-        cpu->pc += 2; // NOLINT
-        num_cycles = 10;
+        cpu->pc += 2;    // NOLINT
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0xcd:                                                   // NOLINT
@@ -457,7 +457,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp += 1;
         cpu->d = cpu_read_mem(cpu, cpu->sp);
         cpu->sp += 1;
-        num_cycles = 10;
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0xd3: // NOLINT
@@ -467,15 +467,15 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint8_t port = cpu_read_mem(cpu, cpu->pc + 1);
         printf("%u", port);
         cpu->pc += 1;
-        num_cycles = 10;
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0xd5: // NOLINT
       {        // PUSH D
         cpu_write_mem(cpu, cpu->sp - 2, cpu->e);
         cpu_write_mem(cpu, cpu->sp - 1, cpu->d);
-        cpu->sp -= 2;
-        num_cycles = 11;
+        cpu->sp -= 2;    // NOLINT
+        num_cycles = 11; // NOLINT
         break;
       }
     case 0xda: // NOLINT
@@ -488,7 +488,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             return 10; // return cycle number
           }
         cpu->pc += 2;
-        num_cycles = 10;
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0xdb: // NOLINT
@@ -496,15 +496,15 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint8_t port = cpu_read_mem(cpu, cpu->pc + 1);
         printf("%u", port);
         cpu->pc += 1;
-        num_cycles = 10;
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0xe1: // NOLINT
       {        // POP H
         cpu->l = cpu_read_mem(cpu, cpu->sp);
         cpu->h = cpu_read_mem(cpu, cpu->sp + 1);
-        cpu->sp += 2;
-        num_cycles = 10;
+        cpu->sp += 2;    // NOLINT
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0xe5: // NOLINT
@@ -513,7 +513,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 1;
         cpu_write_mem(cpu, cpu->sp - 1, cpu->l);
         cpu->sp -= 1;
-        num_cycles = 11;
+        num_cycles = 11; // NOLINT
         break;
       }
     case 0xe6: // NOLINT
@@ -526,7 +526,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_carry_flag(cpu, false);
         cpu->flags &= ~FLAG_AC;
         cpu->pc += 1;
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0xeb: // NOLINT
@@ -540,7 +540,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         temp = cpu->l;
         cpu->l = cpu->e;
         cpu->e = temp;
-        num_cycles = 5;
+        num_cycles = 5; // NOLINT
         break;
       }
     case 0xf1: // NOLINT
@@ -548,7 +548,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->flags = cpu_read_mem(cpu, cpu->sp);
         cpu->a = cpu_read_mem(cpu, cpu->sp + 1);
         cpu->sp += 2;
-        num_cycles = 10;
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0xf5: // NOLINT
@@ -557,14 +557,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 1;
         cpu_write_mem(cpu, cpu->sp - 1, cpu->flags);
         cpu->sp -= 1;
-        num_cycles = 11;
+        num_cycles = 11; // NOLINT
         break;
       }
       break;
     case 0xfb: // NOLINT
       {
         cpu->interrupt_enabled = true;
-        num_cycles = 4;
+        num_cycles = 4; // NOLINT
         break;
       }
     case 0xfe: // NOLINT
@@ -577,7 +577,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_carry_flag(cpu, (data > cpu->a));
         update_aux_carry_flag(cpu, cpu->a, (~data + 1));
         cpu->pc += 1;
-        num_cycles = 7;
+        num_cycles = 7; // NOLINT
         break;
       }
     default:

--- a/emulator.c
+++ b/emulator.c
@@ -13,16 +13,20 @@
 int
 execute_instruction(i8080 *cpu, uint8_t opcode)
 {
+  int num_cycles = 0;
   switch (opcode)
     {
     case 0x00: // NOLINT
-      // NOP
-      break;
+      {        // NOP
+        num_cycles = 4;
+        break;
+      }
     case 0x01: // NOLINT
       {        // LXI B
         cpu->c = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->b = cpu_read_mem(cpu, cpu->pc + 2);
         cpu->pc += 2;
+	num_cycles = 10; 
         break;
       }
     case 0x05: // NOLINT
@@ -33,6 +37,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_sign_flag(cpu, cpu->b);
         update_parity_flag(cpu, cpu->b);
         update_aux_carry_flag(cpu, cpu->b, 0xFF); // NOLINT
+        num_cycles = 5;
 
         break;
       }
@@ -40,6 +45,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       {        // MVI B, mem8
         cpu->b = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->pc += 1;
+	num_cycles = 7; 
         break;
       }
     case 0x09: // NOLINT
@@ -51,6 +57,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_carry_flag(cpu, result > 0xFFFF); // NOLINT
         cpu->h = (result & 0xff00) >> 8;         // NOLINT
         cpu->l = (result & 0xff);                // NOLINT
+	num_cycles = 10; 
         break;
       }
     case 0x0d: // NOLINT
@@ -61,12 +68,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_parity_flag(cpu, result);
         update_aux_carry_flag(cpu, cpu->c, 0xFF); // NOLINT
         cpu->c = result;
+	num_cycles = 5; 
         break;
       }
     case 0x0e: // NOLINT
       {        // MVI C, D8
         cpu->c = cpu_read_mem(cpu, (cpu->pc + 1));
         cpu->pc += 1;
+	num_cycles = 7; 
         break;
       }
     case 0x0f: // NOLINT
@@ -90,14 +99,15 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
           {
             update_carry_flag(cpu, false);
           }
+	num_cycles = 4; 
         break;
       }
     case 0x11: // NOLINT
-      // printf("LXI D")
       {
         cpu->e = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->d = cpu_read_mem(cpu, cpu->pc + 2);
         cpu->pc += 2;
+	num_cycles = 10; 
         break;
       }
     case 0x13: // NOLINT
@@ -108,6 +118,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             cpu->d += 1;
           }
         break;
+	num_cycles = 5; 
       }
     case 0x19: // NOLINT
       {        // DAD D
@@ -123,6 +134,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->h = sum >> 8;                      // NOLINT
         cpu->l = sum & 0xFF;                    // NOLINT
         update_carry_flag(cpu, (sum > 0xFFFF)); // NOLINT
+	num_cycles = 10; 
 
         break;
       }
@@ -138,6 +150,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
 
         // put value in a
         cpu->a = val;
+	num_cycles = 7; 
         break;
       }
     case 0x21: // NOLINT
@@ -146,6 +159,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->l = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->h = cpu_read_mem(cpu, cpu->pc + 2);
         cpu->pc += 2;
+	num_cycles = 10; 
         break;
       }
     case 0x23: // NOLINT
@@ -155,12 +169,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
           {
             cpu->h += 1;
           }
+	num_cycles = 5;
         break;
       }
     case 0x26: // NOLINT
       {        // MVI H, D8
         cpu->h = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->pc += 1;
+	num_cycles = 7;
         break;
       }
     case 0x29: // NOLINT
@@ -175,15 +191,16 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         // put values back in registers
         cpu->l = sum;
         cpu->h = (sum >> 8); // NOLINT
+	num_cycles = 10; // NOLINT
         break;
       }
     case 0x31: // NOLINT
-      // printf("LXI SP");
       {
         // NOLINTNEXTLINE
         cpu->sp = cpu_read_mem(cpu, cpu->pc + 1)
                   | (cpu_read_mem(cpu, cpu->pc + 2) << 8); // NOLINT
         cpu->pc += 2;
+	num_cycles = 10; // NOLINT
         break;
       }
     case 0x32: // NOLINT
@@ -194,6 +211,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         address += (cpu_read_mem(cpu, cpu->pc + 2) << 8); // NOLINT
         cpu_write_mem(cpu, address, cpu->a);
         cpu->pc += 2;
+	num_cycles = 13; // NOLINT
         break;
       }
     case 0x35: // NOLINT
@@ -207,6 +225,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_parity_flag(cpu, result);
         update_aux_carry_flag(cpu, mem_value, 0xFF); // NOLINT
         cpu_write_mem(cpu, address, result);
+	num_cycles = 10; // NOLINT
         break;
       }
     case 0x36: // NOLINT
@@ -217,6 +236,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu_write_mem(cpu, address, cpu_read_mem(cpu, cpu->pc + 1));
 
         cpu->pc += 1;
+	num_cycles = 10;
         break;
       }
     case 0x3a: // NOLINT
@@ -225,13 +245,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         addr = (addr << 8) + cpu_read_mem(cpu, cpu->pc + 1); // NOLINT
         cpu->a = cpu_read_mem(cpu, addr);
         cpu->pc += 2;
+	num_cycles = 13;
         break;
       }
     case 0x3e: // NOLINT
-      // printf("MVI A");
       {
         cpu->a = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->pc += 1;
+	num_cycles = 7;
         break;
       }
     case 0x56: // NOLINT
@@ -240,6 +261,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu->l;
         address += (cpu->h << 8); // NOLINT
         cpu->d = cpu_read_mem(cpu, address);
+	num_cycles = 7;
         break;
       }
     case 0x5e: // NOLINT
@@ -248,7 +270,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = (cpu->h << 8) | cpu->l; // NOLINT
 
         cpu->e = cpu_read_mem(cpu, address);
-
+	num_cycles = 7;
         break;
       }
     case 0x66: // NOLINT
@@ -256,12 +278,13 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t addr = cpu->h;
         addr = (addr << 8) + cpu->l; // NOLINT
         cpu->h = cpu_read_mem(cpu, addr);
+	num_cycles = 7;
         break;
       }
     case 0x6f: // NOLINT
       {
-        // printf("MOV L,A");
         cpu->l = cpu->a;
+	num_cycles = 5;
         break;
       }
     case 0x77: // NOLINT
@@ -269,22 +292,25 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu->l;
         address += (cpu->h << 8); // NOLINT
         cpu_write_mem(cpu, address, cpu->a);
+	num_cycles = 7;
         break;
       }
     case 0x7a: // NOLINT
       {        // MOV A,D
         cpu->a = cpu->d;
+	num_cycles = 5;
         break;
       }
     case 0x7b: // NOLINT
       {        // MOV A,E
         cpu->a = cpu->e;
+	num_cycles = 5;
         break;
       }
     case 0x7c: // NOLINT
       {
-        // printf("MOV A,H");
         cpu->a = cpu->h;
+	num_cycles = 5;
         break;
       }
     case 0x7e: // NOLINT
@@ -292,6 +318,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu->l;
         address += (cpu->h << 8); // NOLINT
         cpu->a = cpu_read_mem(cpu, address);
+	num_cycles = 7;
         break;
       }
     case 0xa7: // NOLINT
@@ -304,6 +331,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_parity_flag(cpu, cpu->a);
         update_aux_carry_flag(cpu, temp, cpu->a);
         update_carry_flag(cpu, false);
+	num_cycles = 4;
 
         break;
       }
@@ -317,15 +345,16 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_aux_carry_flag(cpu, result, 0xFF); // NOLINT
 
         cpu->a = result;
+	num_cycles = 4;
+
         break;
       }
     case 0xc1: // NOLINT
       {
-        // printf("POP B")
         cpu->c = cpu_read_mem(cpu, cpu->sp);
         cpu->b = cpu_read_mem(cpu, cpu->sp + 1);
         cpu->sp += 2;
-        // NOT NEEDED cpu->pc += 1;
+	num_cycles = 10;
         break;
       }
     case 0xc2: // NOLINT
@@ -337,9 +366,10 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             // returns rather than breaks to avoid pc increment at end of
             // function
             cpu->pc = address;
-            return 0;
+            return 10; // return cycle number 
           }
         cpu->pc += 2;
+	num_cycles = 10;
         break;
       }
     case 0xc3: // NOLINT
@@ -348,7 +378,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu_read_mem(cpu, cpu->pc + 2);
         address = (address << 8) | cpu_read_mem(cpu, cpu->pc + 1); // NOLINT
         cpu->pc = address;
-        return 0; // no PC increment due to JMP.
+        return 10; // no PC increment due to JMP, return num cycles
       }
     case 0xc5: // NOLINT
       {        // PUSH B
@@ -356,11 +386,11 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 1;
         cpu_write_mem(cpu, cpu->sp - 1, cpu->c);
         cpu->sp -= 1;
+        num_cycles = 11;   
         break;
       }
     case 0xc6: // NOLINT
       {
-        // printf("ADI ");
         // Affects Z, S, P, CY, AC
         uint8_t immediate = cpu_read_mem(cpu, cpu->pc + 1);
         uint16_t answer = cpu->a + immediate;
@@ -371,6 +401,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_aux_carry_flag(cpu, cpu->a, immediate);
         cpu->a = (uint8_t)answer;
         cpu->pc += 1;
+        num_cycles = 7;   
         break;
       }
     case 0xc9: // NOLINT
@@ -380,7 +411,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         address += (cpu_read_mem(cpu, cpu->sp + 1) << 8); // NOLINT
         cpu->sp += 2;
         cpu->pc = address;
-        return 0;
+        return 10; // return num cycles
       }
     case 0xca: // NOLINT
       {        // JZ
@@ -390,9 +421,10 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             address = address << 8;                            // NOLINT
             address += cpu_read_mem(cpu, cpu->pc + 1);
             cpu->pc = address;
-            return 0;
+            return 10; // return num cycles
           }
         cpu->pc += 2; // NOLINT
+	num_cycles = 10;
         break;
       }
     case 0xcd:                                                   // NOLINT
@@ -403,7 +435,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 2;
         cpu->pc = (cpu_read_mem(cpu, cpu->pc + 2) << 8) // NOLINT
                   | (cpu_read_mem(cpu, cpu->pc + 1));
-        return 0;
+        return 17; // return num cycles
       }
     case 0xd1: // NOLINT
       {
@@ -412,6 +444,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp += 1;
         cpu->d = cpu_read_mem(cpu, cpu->sp);
         cpu->sp += 1;
+        num_cycles = 10;   
         break;
       }
     case 0xd3: // NOLINT
@@ -421,6 +454,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint8_t port = cpu_read_mem(cpu, cpu->pc + 1);
         printf("%u", port);
         cpu->pc += 1;
+        num_cycles = 10;   
         break;
       }
     case 0xd5: // NOLINT
@@ -428,6 +462,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu_write_mem(cpu, cpu->sp - 2, cpu->e);
         cpu_write_mem(cpu, cpu->sp - 1, cpu->d);
         cpu->sp -= 2;
+        num_cycles = 11;   
         break;
       }
     case 0xda: // NOLINT
@@ -437,9 +472,10 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         if ((cpu->flags & FLAG_CY) == FLAG_CY) // if CY set JUMP
           {
             cpu->pc = address;
-            return 0;
+            return 10; // return cycle number 
           }
         cpu->pc += 2;
+	num_cycles = 10;
         break;
       }
     case 0xdb: // NOLINT
@@ -447,6 +483,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint8_t port = cpu_read_mem(cpu, cpu->pc + 1);
         printf("%u", port);
         cpu->pc += 1;
+	num_cycles = 10; 
         break;
       }
     case 0xe1: // NOLINT
@@ -454,6 +491,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->l = cpu_read_mem(cpu, cpu->sp);
         cpu->h = cpu_read_mem(cpu, cpu->sp + 1);
         cpu->sp += 2;
+        num_cycles = 10;   
         break;
       }
     case 0xe5: // NOLINT
@@ -462,11 +500,11 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 1;
         cpu_write_mem(cpu, cpu->sp - 1, cpu->l);
         cpu->sp -= 1;
+        num_cycles = 11;   
         break;
       }
     case 0xe6: // NOLINT
       {
-        // printf("ANI ");
         uint8_t immediate = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->a &= immediate;
         update_zero_flag(cpu, cpu->a);
@@ -475,6 +513,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_carry_flag(cpu, false);
         cpu->flags &= ~FLAG_AC;
         cpu->pc += 1;
+        num_cycles = 7;   
         break;
       }
     case 0xeb: // NOLINT
@@ -488,6 +527,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         temp = cpu->l;
         cpu->l = cpu->e;
         cpu->e = temp;
+        num_cycles = 5;   
         break;
       }
     case 0xf1: // NOLINT
@@ -495,6 +535,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->flags = cpu_read_mem(cpu, cpu->sp);
         cpu->a = cpu_read_mem(cpu, cpu->sp + 1);
         cpu->sp += 2;
+        num_cycles = 10;   
         break;
       }
     case 0xf5: // NOLINT
@@ -503,12 +544,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 1;
         cpu_write_mem(cpu, cpu->sp - 1, cpu->flags);
         cpu->sp -= 1;
+        num_cycles = 11;   
         break;
       }
       break;
     case 0xfb: // NOLINT
       {
         cpu->interrupt_enabled = true;
+        num_cycles = 4;   
         break;
       }
     case 0xfe: // NOLINT
@@ -521,6 +564,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_carry_flag(cpu, (data > cpu->a));
         update_aux_carry_flag(cpu, cpu->a, (~data + 1));
         cpu->pc += 1;
+        num_cycles = 7;   
         break;
       }
     default:
@@ -530,8 +574,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       }
     }
   cpu->pc += 1;
-  printf("cpu->pc: %x\n", cpu->pc);
-  return 0;
+  return num_cycles;
 }
 
 void
@@ -714,8 +757,8 @@ void
 print_state(i8080 *cpu)
 {
   printf("REGISTERS a: 0x%02x b: 0x%02x c: 0x%02x d: 0x%02x e: 0x%02x h: "
-         "0x%02x l: 0x%02x ",
-         cpu->a, cpu->b, cpu->c, cpu->d, cpu->e, cpu->h, cpu->l);
+         "0x%02x l: 0x%02x sp: 0x%02x pc: 0x%02x ",
+         cpu->a, cpu->b, cpu->c, cpu->d, cpu->e, cpu->h, cpu->l, cpu->sp, cpu->pc);
 }
 
 void

--- a/emulator.c
+++ b/emulator.c
@@ -420,19 +420,6 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         num_cycles = 5; // NOLINT
         break;
       }
-    case 0xc8:                               // NOLINT
-      {                                      // RZ
-        if ((cpu->flags & FLAG_Z) == FLAG_Z) // if Z set, RET
-          {
-            uint16_t address = cpu_read_mem(cpu, cpu->sp);
-            address += (cpu_read_mem(cpu, cpu->sp + 1) << 8); // NOLINT
-            cpu->sp += 2;
-            cpu->pc = address;
-            // NOLINTNEXTLINE
-            return 0;
-          }
-        break;
-      }
     case 0xc9: // NOLINT
       {        // RET
         // returns rather than breaks to avoid pc increment at end of function

--- a/emulator.c
+++ b/emulator.c
@@ -26,7 +26,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->c = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->b = cpu_read_mem(cpu, cpu->pc + 2);
         cpu->pc += 2;
-	num_cycles = 10; 
+        num_cycles = 10;
         break;
       }
     case 0x05: // NOLINT
@@ -45,7 +45,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       {        // MVI B, mem8
         cpu->b = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->pc += 1;
-	num_cycles = 7; 
+        num_cycles = 7;
         break;
       }
     case 0x09: // NOLINT
@@ -57,7 +57,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_carry_flag(cpu, result > 0xFFFF); // NOLINT
         cpu->h = (result & 0xff00) >> 8;         // NOLINT
         cpu->l = (result & 0xff);                // NOLINT
-	num_cycles = 10; 
+        num_cycles = 10;
         break;
       }
     case 0x0d: // NOLINT
@@ -68,14 +68,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_parity_flag(cpu, result);
         update_aux_carry_flag(cpu, cpu->c, 0xFF); // NOLINT
         cpu->c = result;
-	num_cycles = 5; 
+        num_cycles = 5;
         break;
       }
     case 0x0e: // NOLINT
       {        // MVI C, D8
         cpu->c = cpu_read_mem(cpu, (cpu->pc + 1));
         cpu->pc += 1;
-	num_cycles = 7; 
+        num_cycles = 7;
         break;
       }
     case 0x0f: // NOLINT
@@ -99,7 +99,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
           {
             update_carry_flag(cpu, false);
           }
-	num_cycles = 4; 
+        num_cycles = 4;
         break;
       }
     case 0x11: // NOLINT
@@ -107,7 +107,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->e = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->d = cpu_read_mem(cpu, cpu->pc + 2);
         cpu->pc += 2;
-	num_cycles = 10; 
+        num_cycles = 10;
         break;
       }
     case 0x13: // NOLINT
@@ -118,7 +118,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             cpu->d += 1;
           }
         break;
-	num_cycles = 5; 
+        num_cycles = 5;
       }
     case 0x19: // NOLINT
       {        // DAD D
@@ -134,7 +134,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->h = sum >> 8;                      // NOLINT
         cpu->l = sum & 0xFF;                    // NOLINT
         update_carry_flag(cpu, (sum > 0xFFFF)); // NOLINT
-	num_cycles = 10; 
+        num_cycles = 10;
 
         break;
       }
@@ -150,7 +150,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
 
         // put value in a
         cpu->a = val;
-	num_cycles = 7; 
+        num_cycles = 7;
         break;
       }
     case 0x21: // NOLINT
@@ -159,7 +159,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->l = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->h = cpu_read_mem(cpu, cpu->pc + 2);
         cpu->pc += 2;
-	num_cycles = 10; 
+        num_cycles = 10;
         break;
       }
     case 0x23: // NOLINT
@@ -169,14 +169,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
           {
             cpu->h += 1;
           }
-	num_cycles = 5;
+        num_cycles = 5;
         break;
       }
     case 0x26: // NOLINT
       {        // MVI H, D8
         cpu->h = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->pc += 1;
-	num_cycles = 7;
+        num_cycles = 7;
         break;
       }
     case 0x29: // NOLINT
@@ -191,7 +191,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         // put values back in registers
         cpu->l = sum;
         cpu->h = (sum >> 8); // NOLINT
-	num_cycles = 10; // NOLINT
+        num_cycles = 10;     // NOLINT
         break;
       }
     case 0x31: // NOLINT
@@ -200,7 +200,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp = cpu_read_mem(cpu, cpu->pc + 1)
                   | (cpu_read_mem(cpu, cpu->pc + 2) << 8); // NOLINT
         cpu->pc += 2;
-	num_cycles = 10; // NOLINT
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0x32: // NOLINT
@@ -211,7 +211,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         address += (cpu_read_mem(cpu, cpu->pc + 2) << 8); // NOLINT
         cpu_write_mem(cpu, address, cpu->a);
         cpu->pc += 2;
-	num_cycles = 13; // NOLINT
+        num_cycles = 13; // NOLINT
         break;
       }
     case 0x35: // NOLINT
@@ -225,7 +225,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_parity_flag(cpu, result);
         update_aux_carry_flag(cpu, mem_value, 0xFF); // NOLINT
         cpu_write_mem(cpu, address, result);
-	num_cycles = 10; // NOLINT
+        num_cycles = 10; // NOLINT
         break;
       }
     case 0x36: // NOLINT
@@ -236,7 +236,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu_write_mem(cpu, address, cpu_read_mem(cpu, cpu->pc + 1));
 
         cpu->pc += 1;
-	num_cycles = 10;
+        num_cycles = 10;
         break;
       }
     case 0x3a: // NOLINT
@@ -245,14 +245,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         addr = (addr << 8) + cpu_read_mem(cpu, cpu->pc + 1); // NOLINT
         cpu->a = cpu_read_mem(cpu, addr);
         cpu->pc += 2;
-	num_cycles = 13;
+        num_cycles = 13;
         break;
       }
     case 0x3e: // NOLINT
       {
         cpu->a = cpu_read_mem(cpu, cpu->pc + 1);
         cpu->pc += 1;
-	num_cycles = 7;
+        num_cycles = 7;
         break;
       }
     case 0x56: // NOLINT
@@ -261,7 +261,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu->l;
         address += (cpu->h << 8); // NOLINT
         cpu->d = cpu_read_mem(cpu, address);
-	num_cycles = 7;
+        num_cycles = 7;
         break;
       }
     case 0x5e: // NOLINT
@@ -270,7 +270,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = (cpu->h << 8) | cpu->l; // NOLINT
 
         cpu->e = cpu_read_mem(cpu, address);
-	num_cycles = 7;
+        num_cycles = 7;
         break;
       }
     case 0x66: // NOLINT
@@ -278,13 +278,13 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t addr = cpu->h;
         addr = (addr << 8) + cpu->l; // NOLINT
         cpu->h = cpu_read_mem(cpu, addr);
-	num_cycles = 7;
+        num_cycles = 7;
         break;
       }
     case 0x6f: // NOLINT
       {
         cpu->l = cpu->a;
-	num_cycles = 5;
+        num_cycles = 5;
         break;
       }
     case 0x77: // NOLINT
@@ -292,25 +292,25 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu->l;
         address += (cpu->h << 8); // NOLINT
         cpu_write_mem(cpu, address, cpu->a);
-	num_cycles = 7;
+        num_cycles = 7;
         break;
       }
     case 0x7a: // NOLINT
       {        // MOV A,D
         cpu->a = cpu->d;
-	num_cycles = 5;
+        num_cycles = 5;
         break;
       }
     case 0x7b: // NOLINT
       {        // MOV A,E
         cpu->a = cpu->e;
-	num_cycles = 5;
+        num_cycles = 5;
         break;
       }
     case 0x7c: // NOLINT
       {
         cpu->a = cpu->h;
-	num_cycles = 5;
+        num_cycles = 5;
         break;
       }
     case 0x7e: // NOLINT
@@ -318,7 +318,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint16_t address = cpu->l;
         address += (cpu->h << 8); // NOLINT
         cpu->a = cpu_read_mem(cpu, address);
-	num_cycles = 7;
+        num_cycles = 7;
         break;
       }
     case 0xa7: // NOLINT
@@ -331,7 +331,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_parity_flag(cpu, cpu->a);
         update_aux_carry_flag(cpu, temp, cpu->a);
         update_carry_flag(cpu, false);
-	num_cycles = 4;
+        num_cycles = 4;
 
         break;
       }
@@ -345,7 +345,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_aux_carry_flag(cpu, result, 0xFF); // NOLINT
 
         cpu->a = result;
-	num_cycles = 4;
+        num_cycles = 4;
 
         break;
       }
@@ -354,7 +354,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->c = cpu_read_mem(cpu, cpu->sp);
         cpu->b = cpu_read_mem(cpu, cpu->sp + 1);
         cpu->sp += 2;
-	num_cycles = 10;
+        num_cycles = 10;
         break;
       }
     case 0xc2: // NOLINT
@@ -366,10 +366,10 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             // returns rather than breaks to avoid pc increment at end of
             // function
             cpu->pc = address;
-            return 10; // return cycle number 
+            return 10; // return cycle number
           }
         cpu->pc += 2;
-	num_cycles = 10;
+        num_cycles = 10;
         break;
       }
     case 0xc3: // NOLINT
@@ -386,7 +386,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 1;
         cpu_write_mem(cpu, cpu->sp - 1, cpu->c);
         cpu->sp -= 1;
-        num_cycles = 11;   
+        num_cycles = 11;
         break;
       }
     case 0xc6: // NOLINT
@@ -401,7 +401,20 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_aux_carry_flag(cpu, cpu->a, immediate);
         cpu->a = (uint8_t)answer;
         cpu->pc += 1;
-        num_cycles = 7;   
+        num_cycles = 7;
+        break;
+      }
+    case 0xc8:                               // NOLINT
+      {                                      // RZ
+        if ((cpu->flags & FLAG_Z) == FLAG_Z) // if Z set, RET
+          {
+            uint16_t address = cpu_read_mem(cpu, cpu->sp);
+            address += (cpu_read_mem(cpu, cpu->sp + 1) << 8); // NOLINT
+            cpu->sp += 2;
+            cpu->pc = address;
+            return 11; // return num cycles
+          }
+        num_cycles = 5;
         break;
       }
     case 0xc9: // NOLINT
@@ -424,7 +437,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
             return 10; // return num cycles
           }
         cpu->pc += 2; // NOLINT
-	num_cycles = 10;
+        num_cycles = 10;
         break;
       }
     case 0xcd:                                                   // NOLINT
@@ -444,7 +457,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp += 1;
         cpu->d = cpu_read_mem(cpu, cpu->sp);
         cpu->sp += 1;
-        num_cycles = 10;   
+        num_cycles = 10;
         break;
       }
     case 0xd3: // NOLINT
@@ -454,7 +467,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint8_t port = cpu_read_mem(cpu, cpu->pc + 1);
         printf("%u", port);
         cpu->pc += 1;
-        num_cycles = 10;   
+        num_cycles = 10;
         break;
       }
     case 0xd5: // NOLINT
@@ -462,7 +475,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu_write_mem(cpu, cpu->sp - 2, cpu->e);
         cpu_write_mem(cpu, cpu->sp - 1, cpu->d);
         cpu->sp -= 2;
-        num_cycles = 11;   
+        num_cycles = 11;
         break;
       }
     case 0xda: // NOLINT
@@ -472,10 +485,10 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         if ((cpu->flags & FLAG_CY) == FLAG_CY) // if CY set JUMP
           {
             cpu->pc = address;
-            return 10; // return cycle number 
+            return 10; // return cycle number
           }
         cpu->pc += 2;
-	num_cycles = 10;
+        num_cycles = 10;
         break;
       }
     case 0xdb: // NOLINT
@@ -483,7 +496,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         uint8_t port = cpu_read_mem(cpu, cpu->pc + 1);
         printf("%u", port);
         cpu->pc += 1;
-	num_cycles = 10; 
+        num_cycles = 10;
         break;
       }
     case 0xe1: // NOLINT
@@ -491,7 +504,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->l = cpu_read_mem(cpu, cpu->sp);
         cpu->h = cpu_read_mem(cpu, cpu->sp + 1);
         cpu->sp += 2;
-        num_cycles = 10;   
+        num_cycles = 10;
         break;
       }
     case 0xe5: // NOLINT
@@ -500,7 +513,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 1;
         cpu_write_mem(cpu, cpu->sp - 1, cpu->l);
         cpu->sp -= 1;
-        num_cycles = 11;   
+        num_cycles = 11;
         break;
       }
     case 0xe6: // NOLINT
@@ -513,7 +526,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_carry_flag(cpu, false);
         cpu->flags &= ~FLAG_AC;
         cpu->pc += 1;
-        num_cycles = 7;   
+        num_cycles = 7;
         break;
       }
     case 0xeb: // NOLINT
@@ -527,7 +540,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         temp = cpu->l;
         cpu->l = cpu->e;
         cpu->e = temp;
-        num_cycles = 5;   
+        num_cycles = 5;
         break;
       }
     case 0xf1: // NOLINT
@@ -535,7 +548,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->flags = cpu_read_mem(cpu, cpu->sp);
         cpu->a = cpu_read_mem(cpu, cpu->sp + 1);
         cpu->sp += 2;
-        num_cycles = 10;   
+        num_cycles = 10;
         break;
       }
     case 0xf5: // NOLINT
@@ -544,14 +557,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         cpu->sp -= 1;
         cpu_write_mem(cpu, cpu->sp - 1, cpu->flags);
         cpu->sp -= 1;
-        num_cycles = 11;   
+        num_cycles = 11;
         break;
       }
       break;
     case 0xfb: // NOLINT
       {
         cpu->interrupt_enabled = true;
-        num_cycles = 4;   
+        num_cycles = 4;
         break;
       }
     case 0xfe: // NOLINT
@@ -564,7 +577,7 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_carry_flag(cpu, (data > cpu->a));
         update_aux_carry_flag(cpu, cpu->a, (~data + 1));
         cpu->pc += 1;
-        num_cycles = 7;   
+        num_cycles = 7;
         break;
       }
     default:
@@ -758,7 +771,8 @@ print_state(i8080 *cpu)
 {
   printf("REGISTERS a: 0x%02x b: 0x%02x c: 0x%02x d: 0x%02x e: 0x%02x h: "
          "0x%02x l: 0x%02x sp: 0x%02x pc: 0x%02x ",
-         cpu->a, cpu->b, cpu->c, cpu->d, cpu->e, cpu->h, cpu->l, cpu->sp, cpu->pc);
+         cpu->a, cpu->b, cpu->c, cpu->d, cpu->e, cpu->h, cpu->l, cpu->sp,
+         cpu->pc);
 }
 
 void

--- a/emulator.c
+++ b/emulator.c
@@ -777,7 +777,7 @@ void
 print_state(i8080 *cpu)
 {
   printf("REGISTERS a: 0x%02x b: 0x%02x c: 0x%02x d: 0x%02x e: 0x%02x h: "
-         "0x%02x l: 0x%02x sp: 0x%02x pc: 0x%02x ",
+         "0x%02x l: 0x%02x sp: 0x%04x pc: 0x%04x ",
          cpu->a, cpu->b, cpu->c, cpu->d, cpu->e, cpu->h, cpu->l, cpu->sp,
          cpu->pc);
 }

--- a/shell.c
+++ b/shell.c
@@ -1,17 +1,25 @@
 #include "emulator.h"
+#include <SDL2/SDL.h>
 #include <ctype.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <math.h>
+
+#define CLOCK_SPEED_MS 2000
+#define TICK 1000 * (1.0 / 60.0)
+#define CYCLES_PER_TICK (CLOCK_SPEED_MS * TICK)  
+
+int run_cpu(i8080*, int);
+int pflag = 0;
+int dflag = 0;
+int opt;
 
 int
 main(int argc, char *argv[])
 {
-  int pflag = 0;
-  int dflag = 0;
-  int opt;
 
   while ((opt = getopt(argc, argv, "pd")) != -1)
     {
@@ -60,13 +68,54 @@ main(int argc, char *argv[])
       exit(EXIT_FAILURE);
     }
 
+  // start timer
+  uint64_t last_tick = SDL_GetTicks();
+
+  // set initial offset value
+  int cycle_offset = 0;
+  int num_cycles = CYCLES_PER_TICK;
+
   while (true)
     {
-      // 1 Fetch, decode, and execute next instruction
-      // fetch_decode_execute(&cpu)
+      if ((SDL_GetTicks() - last_tick) > TICK)
+        {
+          //printf("Start Time... %lu\n", last_tick);
 
-      // fetch and execute next instruction
-      uint8_t next_instruction = cpu_read_mem(&cpu, cpu.pc);
+	  // run first half of tick cycles
+          cycle_offset = run_cpu(&cpu, (num_cycles - (abs(cycle_offset) / 2)));
+          //printf("Time after first half... %u\n", SDL_GetTicks());
+
+          // first interrupt
+	  handle_interrupt(&cpu, 0x01);  
+
+	  // run second half of tick cycles
+          cycle_offset = run_cpu(&cpu, (num_cycles - (abs(cycle_offset) / 2)));
+          //printf("Time after second half... %u\n", SDL_GetTicks());
+
+	  // second interrupt
+	  handle_interrupt(&cpu, 0x02);  
+
+	  // set number of cycles for next tick
+	  num_cycles = CYCLES_PER_TICK - cycle_offset; 
+
+          // 3 Update system state for display, input, and sound
+
+          // 4 Check for exit conditions
+	   
+          last_tick = SDL_GetTicks();
+        }
+    }
+}
+
+int
+run_cpu(i8080 *cpu, int cycles)
+{
+//printf("num cycles: %d\n", cycles);
+
+  // fetch and execute next instruction
+  while (cycles > 0)
+    {
+      uint8_t next_instruction = cpu_read_mem(cpu, cpu->pc);
       if (pflag)
         {
           print_instruction(next_instruction);
@@ -74,31 +123,77 @@ main(int argc, char *argv[])
       if (dflag)
         {
           printf("PRE-INSTRUCTION  ");
-          print_state(&cpu);
-          print_flags(cpu.flags);
+          print_state(cpu);
+          print_flags(cpu->flags);
           printf("\n");
-        }
-      if (execute_instruction(&cpu, next_instruction) < 0)
+        } 
+
+      int num_cycles_used = execute_instruction(cpu, next_instruction);
+
+      // execute instruction failed
+      if (num_cycles_used < 0)
         {
-          fprintf(stderr,
-                  "Unimplemented opcode encountered. Exiting program.\n");
+          fprintf(stderr, "Unimplemented opcode encountered. "
+                          "Exiting program.\n");
           exit(EXIT_FAILURE);
+        }
+      else
+        {
+          cycles -= num_cycles_used;
         }
       if (dflag)
         {
           printf("POST-INSTRUCTION ");
-          print_state(&cpu);
-          print_flags(cpu.flags);
+          print_state(cpu);
+          print_flags(cpu->flags);
           printf("\n");
-        }
-
-      // 2 Handle interrupts
-      // handle_interrupts(&cpu)
-
-      // 3 Update system state for display, input, and sound
-
-      // 4 Check for exit conditions
+        } 
     }
-
-  // Clean up resources and exit
+//printf("num cycles out: %d\n", cycles);
+  return cycles;
 }
+
+          /*
+                            // 1 Fetch, decode, and execute next instruction
+
+                            // fetch and execute next instruction
+                            uint8_t next_instruction = cpu_read_mem(&cpu,
+             cpu.pc); if (pflag)
+                              {
+                                print_instruction(next_instruction);
+                              }
+                            if (dflag)
+                              {
+                                printf("PRE-INSTRUCTION  ");
+                                print_state(&cpu);
+                                print_flags(cpu.flags);
+                                printf("\n");
+                              }
+
+                            int num_cycles_used
+                                = execute_instruction(&cpu, next_instruction);
+
+                            // execute instruction failed
+                            if (num_cycles_used < 0)
+                              {
+                                fprintf(stderr, "Unimplemented opcode
+             encountered. " "Exiting program.\n"); exit(EXIT_FAILURE);
+                              }
+                            else
+                              {
+                                num_remaining_cycles -= num_cycles_used;
+                              }
+                            if (dflag)
+                              {
+                                printf("POST-INSTRUCTION ");
+                                print_state(&cpu);
+                                print_flags(cpu.flags);
+                                printf("\n");
+                              }
+          */
+          // 2 Handle interrupts
+          // handle_interrupts(&cpu)
+
+          // 3 Update system state for display, input, and sound
+
+          // 4 Check for exit conditions

--- a/shell.c
+++ b/shell.c
@@ -1,18 +1,18 @@
 #include "emulator.h"
 #include <SDL2/SDL.h>
 #include <ctype.h>
+#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <math.h>
 
 #define CLOCK_SPEED_MS 2000
-#define TICK 1000 * (1.0 / 60.0)
-#define CYCLES_PER_TICK (CLOCK_SPEED_MS * TICK)  
+#define(TICK 1000 * (1.0 / 60.0))
+#define CYCLES_PER_TICK (CLOCK_SPEED_MS * TICK)
 
-int run_cpu(i8080*, int);
+int run_cpu(i8080 *cpu, int cycles);
 int pflag = 0;
 int dflag = 0;
 int opt;
@@ -77,27 +77,28 @@ main(int argc, char *argv[])
 
   while (true)
     {
-      if ((SDL_GetTicks() - last_tick) > TICK)
+      if ((SDL_GetTicks() - last_tick) > TICK) // NOLINT
         {
-	  // run first half of tick cycles
+          printf("Current tick is: %d\n", SDL_GetTicks());
+          // run first half of tick cycles
           cycle_offset = run_cpu(&cpu, (num_cycles - (abs(cycle_offset) / 2)));
 
           // first interrupt
-	  handle_interrupt(&cpu, 0x01);  
+          handle_interrupt(&cpu, 0x01);
 
-	  // run second half of tick cycles
+          // run second half of tick cycles
           cycle_offset = run_cpu(&cpu, (num_cycles - (abs(cycle_offset) / 2)));
 
-	  // second interrupt
-	  handle_interrupt(&cpu, 0x02);  
+          // second interrupt
+          handle_interrupt(&cpu, 0x02);
 
-	  // set number of cycles for next tick
-	  num_cycles = CYCLES_PER_TICK - cycle_offset; 
+          // set number of cycles for next tick
+          num_cycles = CYCLES_PER_TICK - cycle_offset;
 
           // 3 Update system state for display, input, and sound
 
           // 4 Check for exit conditions
-	   
+
           last_tick = SDL_GetTicks();
         }
     }
@@ -121,7 +122,7 @@ run_cpu(i8080 *cpu, int cycles)
           print_state(cpu);
           print_flags(cpu->flags);
           printf("\n");
-        } 
+        }
 
       int num_cycles_used = execute_instruction(cpu, next_instruction);
 
@@ -142,8 +143,7 @@ run_cpu(i8080 *cpu, int cycles)
           print_state(cpu);
           print_flags(cpu->flags);
           printf("\n");
-        } 
+        }
     }
   return cycles;
 }
-

--- a/shell.c
+++ b/shell.c
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 #define CLOCK_SPEED_MS 2000
-#define (TICK 1000 * (1.0 / 60.0))
+#define TICK (1000 * (1.0 / 60.0))
 #define CYCLES_PER_TICK (CLOCK_SPEED_MS * TICK)
 
 int run_cpu(i8080 *cpu, int cycles);

--- a/shell.c
+++ b/shell.c
@@ -79,18 +79,14 @@ main(int argc, char *argv[])
     {
       if ((SDL_GetTicks() - last_tick) > TICK)
         {
-          //printf("Start Time... %lu\n", last_tick);
-
 	  // run first half of tick cycles
           cycle_offset = run_cpu(&cpu, (num_cycles - (abs(cycle_offset) / 2)));
-          //printf("Time after first half... %u\n", SDL_GetTicks());
 
           // first interrupt
 	  handle_interrupt(&cpu, 0x01);  
 
 	  // run second half of tick cycles
           cycle_offset = run_cpu(&cpu, (num_cycles - (abs(cycle_offset) / 2)));
-          //printf("Time after second half... %u\n", SDL_GetTicks());
 
 	  // second interrupt
 	  handle_interrupt(&cpu, 0x02);  
@@ -110,7 +106,6 @@ main(int argc, char *argv[])
 int
 run_cpu(i8080 *cpu, int cycles)
 {
-//printf("num cycles: %d\n", cycles);
 
   // fetch and execute next instruction
   while (cycles > 0)
@@ -149,51 +144,6 @@ run_cpu(i8080 *cpu, int cycles)
           printf("\n");
         } 
     }
-//printf("num cycles out: %d\n", cycles);
   return cycles;
 }
 
-          /*
-                            // 1 Fetch, decode, and execute next instruction
-
-                            // fetch and execute next instruction
-                            uint8_t next_instruction = cpu_read_mem(&cpu,
-             cpu.pc); if (pflag)
-                              {
-                                print_instruction(next_instruction);
-                              }
-                            if (dflag)
-                              {
-                                printf("PRE-INSTRUCTION  ");
-                                print_state(&cpu);
-                                print_flags(cpu.flags);
-                                printf("\n");
-                              }
-
-                            int num_cycles_used
-                                = execute_instruction(&cpu, next_instruction);
-
-                            // execute instruction failed
-                            if (num_cycles_used < 0)
-                              {
-                                fprintf(stderr, "Unimplemented opcode
-             encountered. " "Exiting program.\n"); exit(EXIT_FAILURE);
-                              }
-                            else
-                              {
-                                num_remaining_cycles -= num_cycles_used;
-                              }
-                            if (dflag)
-                              {
-                                printf("POST-INSTRUCTION ");
-                                print_state(&cpu);
-                                print_flags(cpu.flags);
-                                printf("\n");
-                              }
-          */
-          // 2 Handle interrupts
-          // handle_interrupts(&cpu)
-
-          // 3 Update system state for display, input, and sound
-
-          // 4 Check for exit conditions

--- a/shell.c
+++ b/shell.c
@@ -73,27 +73,31 @@ main(int argc, char *argv[])
 
   // set initial offset value
   int cycle_offset = 0;
-  int num_cycles = CYCLES_PER_TICK;
+  int num_cycles = CYCLES_PER_TICK / 2;
 
   while (true)
     {
       if ((SDL_GetTicks() - last_tick) > TICK) // NOLINT
         {
-          printf("Current tick is: %d\n", SDL_GetTicks());
+          if (pflag)
+            {
+              printf("Current Tick: %d\n", SDL_GetTicks());
+            }
+
           // run first half of tick cycles
-          cycle_offset = run_cpu(&cpu, (num_cycles - (abs(cycle_offset) / 2)));
+          cycle_offset = run_cpu(&cpu, num_cycles - abs(cycle_offset));
 
           // first interrupt
           handle_interrupt(&cpu, 0x01);
 
           // run second half of tick cycles
-          cycle_offset = run_cpu(&cpu, (num_cycles - (abs(cycle_offset) / 2)));
+          cycle_offset = run_cpu(&cpu, num_cycles - abs(cycle_offset));
 
           // second interrupt
           handle_interrupt(&cpu, 0x02);
 
           // set number of cycles for next tick
-          num_cycles = CYCLES_PER_TICK - cycle_offset;
+          num_cycles = CYCLES_PER_TICK / 2 - cycle_offset;
 
           // 3 Update system state for display, input, and sound
 

--- a/shell.c
+++ b/shell.c
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 #define CLOCK_SPEED_MS 2000
-#define(TICK 1000 * (1.0 / 60.0))
+#define (TICK 1000 * (1.0 / 60.0))
 #define CYCLES_PER_TICK (CLOCK_SPEED_MS * TICK)
 
 int run_cpu(i8080 *cpu, int cycles);

--- a/shell.c
+++ b/shell.c
@@ -15,11 +15,11 @@
 int run_cpu(i8080 *cpu, int cycles);
 int pflag = 0;
 int dflag = 0;
-int opt;
 
 int
 main(int argc, char *argv[])
 {
+  int opt;
 
   while ((opt = getopt(argc, argv, "pd")) != -1)
     {

--- a/tests.c
+++ b/tests.c
@@ -506,7 +506,7 @@ test_opcode_0xdb(void)
   cpu_write_mem(&cpu, 0x0001, 0x01);
 
   int code_found = execute_instruction(&cpu, 0xdb); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 2);
   // TODO: check contents of A register to see if byte received from port 1
 
@@ -831,7 +831,7 @@ test_opcode_0x35(void) // NOLINT
   // decrease (HL) from 2 to 1
   int code_found = execute_instruction(&cpu, 0x35); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 1);
   CU_ASSERT(cpu_read_mem(&cpu, 0xAABB) == 0x01); // NOLINT
   CU_ASSERT((cpu.flags & FLAG_P) == 0);
@@ -842,7 +842,7 @@ test_opcode_0x35(void) // NOLINT
   // decrease (HL) from 1 to 0
   code_found = execute_instruction(&cpu, 0x35); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 2);
   CU_ASSERT(cpu_read_mem(&cpu, 0xAABB) == 0x00);
   CU_ASSERT((cpu.flags & FLAG_P) == FLAG_P);
@@ -853,7 +853,7 @@ test_opcode_0x35(void) // NOLINT
   // decrease C from 0 to 255
   code_found = execute_instruction(&cpu, 0x35); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 3);
   CU_ASSERT(cpu_read_mem(&cpu, 0xAABB) == 0xFF);
   CU_ASSERT((cpu.flags & FLAG_P) == FLAG_P);
@@ -1025,13 +1025,13 @@ test_opcode_0xda(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xda); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu.pc, 0x1237); // NOLINT
 
   cpu.flags |= FLAG_CY;
   code_found = execute_instruction(&cpu, 0xda); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu.pc, 0xCCDD); // NOLINT
 
   cpu_write_mem(&cpu, 0x1235, 0x00); // NOLINT

--- a/tests.c
+++ b/tests.c
@@ -451,36 +451,6 @@ test_opcode_0xc6(void)
 }
 
 void
-test_opcode_0xc8(void)
-{ // RZ
-  i8080 cpu;
-  cpu_init(&cpu);
-
-  // case where zero flag not set
-  cpu.pc = 0x4341;                                  // NOLINT
-  update_zero_flag(&cpu, 1);                        // had a remainder
-  int code_found = execute_instruction(&cpu, 0xc8); // NOLINT
-  CU_ASSERT(code_found >= 0);
-  CU_ASSERT(cpu.pc == 0x4342); // NOLINT
-
-  // case where zero flag set
-  cpu_write_mem(&cpu, 0x0001, 0xAA); // NOLINT
-  cpu_write_mem(&cpu, 0x0002, 0xBB); // NOLINT
-  cpu.sp = 0x0001;
-  update_zero_flag(&cpu, 0); // no remainder
-
-  code_found = execute_instruction(&cpu, 0xc8); // NOLINT
-
-  CU_ASSERT(code_found >= 0);
-  CU_ASSERT(cpu.pc == 0xBBAA); // NOLINT
-  CU_ASSERT(cpu.sp == 0x0003); // NOLINT
-
-  // clean up
-  cpu_write_mem(&cpu, 0x0001, 0x00); // NOLINT
-  cpu_write_mem(&cpu, 0x0002, 0x00); // NOLINT
-}
-
-void
 test_opcode_0xca(void)
 { // JZ
   i8080 cpu;

--- a/tests.c
+++ b/tests.c
@@ -451,6 +451,36 @@ test_opcode_0xc6(void)
 }
 
 void
+test_opcode_0xc8(void)
+{ // RZ
+  i8080 cpu;
+  cpu_init(&cpu);
+
+  // case where zero flag not set
+  cpu.pc = 0x4341;                                  // NOLINT
+  update_zero_flag(&cpu, 1);                        // had a remainder
+  int code_found = execute_instruction(&cpu, 0xc8); // NOLINT
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT(cpu.pc == 0x4342); // NOLINT
+
+  // case where zero flag set
+  cpu_write_mem(&cpu, 0x0001, 0xAA); // NOLINT
+  cpu_write_mem(&cpu, 0x0002, 0xBB); // NOLINT
+  cpu.sp = 0x0001;
+  update_zero_flag(&cpu, 0); // no remainder
+
+  code_found = execute_instruction(&cpu, 0xc8); // NOLINT
+
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT(cpu.pc == 0xBBAA); // NOLINT
+  CU_ASSERT(cpu.sp == 0x0003); // NOLINT
+
+  // clean up
+  cpu_write_mem(&cpu, 0x0001, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x0002, 0x00); // NOLINT
+}
+
+void
 test_opcode_0xca(void)
 { // JZ
   i8080 cpu;
@@ -1542,6 +1572,9 @@ main(void)
       || (NULL
           == CU_add_test(pSuite, "test of test_opcode_0xa7()",
                          test_opcode_0xa7))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0xc8()",
+                         test_opcode_0xc8))
       || (NULL
           == CU_add_test(pSuite, "test of test_handle_interrupt()",
                          test_handle_interrupt))

--- a/tests.c
+++ b/tests.c
@@ -505,8 +505,10 @@ test_opcode_0xca(void)
   CU_ASSERT(cpu.pc == 0xa93a); // NOLINT
 
   // cleanup
-  cpu_write_mem(&cpu, 0x0001, 0x00); // NOLINT
-  cpu_write_mem(&cpu, 0x0002, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x4342, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x4343, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x5442, 0x00); // NOLINT
+  cpu_write_mem(&cpu, 0x5443, 0x00); // NOLINT
 }
 
 void

--- a/tests.c
+++ b/tests.c
@@ -28,7 +28,7 @@ test_opcode_0x00(void) // NOLINT
   cpu_init(&cpu);
   uint16_t initial_pc = cpu.pc;
   int code_found = execute_instruction(&cpu, 0x00);
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 1);
 }
 
@@ -43,7 +43,7 @@ test_opcode_0x01(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x01); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 3);
   CU_ASSERT(cpu.c == 0xFF);
   CU_ASSERT(cpu.b == 0x12);
@@ -66,7 +66,7 @@ test_opcode_0x06(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0x06); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(2 == cpu.pc);
   CU_ASSERT(0xCC == cpu.b);
 
@@ -90,7 +90,7 @@ test_opcode_0x09(void)
   int code_found = execute_instruction(&cpu, 0x09);         // NOLINT
   uint16_t result_hl = (cpu.h << 8) | cpu.l;                // NOLINT
   bool carry_occurred = (initial_hl + initial_bc) > 0xFFFF; // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 1);
 
   CU_ASSERT(result_hl == initial_hl + initial_bc);
@@ -112,7 +112,7 @@ test_opcode_0x0d(void) // NOLINT
   // decrease C from 2 to 1
   int code_found = execute_instruction(&cpu, 0x0d); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 1);
   CU_ASSERT(cpu.c == 0x01);
   CU_ASSERT((cpu.flags & FLAG_P) == 0);
@@ -123,7 +123,7 @@ test_opcode_0x0d(void) // NOLINT
   // decrease C from 1 to 0
   code_found = execute_instruction(&cpu, 0x0d); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 2);
   CU_ASSERT(cpu.c == 0x00);
   CU_ASSERT((cpu.flags & FLAG_P) == FLAG_P);
@@ -134,7 +134,7 @@ test_opcode_0x0d(void) // NOLINT
   // decrease C from 0 to 255
   code_found = execute_instruction(&cpu, 0x0d); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 3);
   CU_ASSERT(cpu.c == 0xFF);
   CU_ASSERT((cpu.flags & FLAG_P) == FLAG_P);
@@ -157,7 +157,7 @@ test_opcode_0x0f(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0x0f); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0x66 == cpu.a); // NOLINT
   CU_ASSERT(FLAG_CY != (cpu.flags & FLAG_CY));
@@ -170,7 +170,7 @@ test_opcode_0x0f(void) // NOLINT
   code_found = execute_instruction(&cpu, 0x0f); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(2 == cpu.pc);
   CU_ASSERT(0x9E == cpu.a); // NOLINT
   CU_ASSERT(FLAG_CY == (cpu.flags & FLAG_CY));
@@ -186,7 +186,7 @@ test_opcode_0x11(void)
   cpu_write_mem(&cpu, 0x0002, 0x12); // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x11); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 3);
 
   CU_ASSERT(cpu.e == 0x34);
@@ -205,14 +205,14 @@ test_opcode_0x13(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x13); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 1);
   CU_ASSERT(cpu.e == 1);
   CU_ASSERT(cpu.d == 0);
 
   cpu.e = 0xFF;                                 // NOLINT
   code_found = execute_instruction(&cpu, 0x13); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 2);
   CU_ASSERT(cpu.e == 0);
   CU_ASSERT(cpu.d == 1);
@@ -227,7 +227,7 @@ test_opcode_0x05(void) // NOLINT
   cpu.b = 0xF;                                      // NOLINT
   int code_found = execute_instruction(&cpu, 0x05); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu.b, 14);
   CU_ASSERT((cpu.flags & FLAG_Z) == 0);
   CU_ASSERT((cpu.flags & FLAG_S) == 0);
@@ -247,7 +247,7 @@ test_opcode_0x0e(void)
 
   int code_found = execute_instruction(&cpu, 0x0e); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu.c, 0x19); // NOLINT
 
   cpu_write_mem(&cpu, 0x4342, 0x00); // NOLINT
@@ -268,7 +268,7 @@ test_opcode_0x19(void) // NOLINT
   // Carry set test
   int code_found = execute_instruction(&cpu, 0x19); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.h == 0x3F); // NOLINT
   CU_ASSERT(cpu.l == 0x16); // NOLINT
   CU_ASSERT((cpu.flags & FLAG_CY) == FLAG_CY);
@@ -281,7 +281,7 @@ test_opcode_0x19(void) // NOLINT
 
   code_found = execute_instruction(&cpu, 0x19); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.h == 0x62); // NOLINT
   CU_ASSERT(cpu.l == 0xC8); // NOLINT
   CU_ASSERT((cpu.flags & FLAG_CY) == 0);
@@ -297,7 +297,7 @@ test_opcode_0x21(void)
   cpu_write_mem(&cpu, 0x0002, 0x56); // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x21); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 3);
 
   CU_ASSERT(cpu.l == 0x78);
@@ -320,7 +320,7 @@ test_opcode_0x26(void)
 
   int code_found = execute_instruction(&cpu, 0x26); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu.h, 0x65); // NOLINT
 
   cpu_write_mem(&cpu, 0x4564, 0x00); // NOLINT
@@ -336,7 +336,7 @@ test_opcode_0x31(void)
   cpu_write_mem(&cpu, 0x0002, 0xCD); // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x31); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 3);
 
   CU_ASSERT(cpu.sp == 0xCDAB);
@@ -360,7 +360,7 @@ test_opcode_0x36(void)
 
   int code_found = execute_instruction(&cpu, 0x36); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu_read_mem(&cpu, 0x2312), 0xA1); // NOLINT
 
   cpu_write_mem(&cpu, 0x4353, 0x00); // NOLINT
@@ -375,7 +375,7 @@ test_opcode_0x3e(void)
   cpu_write_mem(&cpu, 0x0001, 0xEF); // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x3e); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 2);
 
   CU_ASSERT(cpu.a == 0xEF);
@@ -393,7 +393,7 @@ test_opcode_0x6f(void)
   cpu.a = 0xBD; // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x6f); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 1);
   CU_ASSERT(cpu.l == 0xBD);
 
@@ -412,7 +412,7 @@ test_opcode_0xc1(void)
   cpu_write_mem(&cpu, cpu.sp + 1, 0x56); // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xc1); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 1);
   CU_ASSERT(cpu.sp == 0x1002);
   CU_ASSERT(cpu.c == 0x78);
@@ -435,7 +435,7 @@ test_opcode_0xc6(void)
   cpu_write_mem(&cpu, 0x0001, 0x28); // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xc6); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 2);
   CU_ASSERT(cpu.a == 0x78);
 
@@ -489,7 +489,7 @@ test_opcode_0xd3(void)
   cpu_write_mem(&cpu, 0x0001, 0x01);
 
   int code_found = execute_instruction(&cpu, 0xd3); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 2);
 
   cpu.a = 0;
@@ -522,7 +522,7 @@ test_opcode_0x7c(void)
   cpu.h = 0xBD; // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x7c); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 1);
   CU_ASSERT(cpu.a == 0xBD);
 
@@ -540,7 +540,7 @@ test_opcode_0xe6(void)
   cpu_write_mem(&cpu, 0x0001, 0x3C); // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xe6); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == initial_pc + 2);
   CU_ASSERT(cpu.a == 0x1C);
 
@@ -564,7 +564,7 @@ test_opcode_0xfb(void)
   cpu.interrupt_enabled = false;
 
   int code_found = execute_instruction(&cpu, 0xfb); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.interrupt_enabled == true);
   CU_ASSERT(cpu.pc == (initial_pc + 1));
 }
@@ -582,7 +582,7 @@ test_opcode_0x5e(void)
 
   int code_found = execute_instruction(&cpu, 0x5e); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu.e, 0x45); // NOLINT
 
   cpu_write_mem(&cpu, 0x1231, 0x00); // NOLINT
@@ -599,7 +599,7 @@ test_opcode_0x7a(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x7a); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.a == 100);
 }
 
@@ -616,7 +616,7 @@ test_opcode_0xa7(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xa7); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.a == 85);
   CU_ASSERT((cpu.flags & FLAG_Z) == 0);
   CU_ASSERT((cpu.flags & FLAG_S) == 0);
@@ -638,7 +638,7 @@ test_opcode_0xe1(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xe1); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.l == 0xBC);    // NOLINT
   CU_ASSERT(cpu.h == 0xFE);    // NOLINT
   CU_ASSERT(cpu.sp == 0xDAE0); // NOLINT
@@ -662,7 +662,7 @@ test_opcode_0xf1(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xf1); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu.flags, 0xA8); // NOLINT
   CU_ASSERT_EQUAL(cpu.a, 0xDE);     // NOLINT
 
@@ -685,7 +685,7 @@ test_opcode_0xcd(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xcd); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu_read_mem(&cpu, temp - 1), 0xAB); // NOLINT
   CU_ASSERT_EQUAL(cpu_read_mem(&cpu, temp - 2), 0xD0); // NOLINT
   CU_ASSERT_EQUAL(cpu.sp, 0xDCBA - 2);                 // NOLINT
@@ -708,7 +708,7 @@ test_opcode_0xc3(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xc3); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT_EQUAL(cpu.pc, 0x9C1E); // NOLINT
 
   cpu_write_mem(&cpu, 0xCDEC, 0x00); // NOLINT
@@ -730,7 +730,7 @@ test_opcode_0x1a(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0x1a); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0xCC == cpu.a); // NOLINT
 
@@ -746,14 +746,14 @@ test_opcode_0x23(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x23); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 1);
   CU_ASSERT(cpu.l == 1);
   CU_ASSERT(cpu.h == 0);
 
   cpu.l = 0xFF;                                 // NOLINT
   code_found = execute_instruction(&cpu, 0x23); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 2);
   CU_ASSERT(cpu.l == 0);
   CU_ASSERT(cpu.h == 1);
@@ -774,7 +774,7 @@ test_opcode_0x29(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0x29); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0x23 == cpu.h); // NOLINT
   CU_ASSERT(0x54 == cpu.l); // NOLINT
@@ -789,7 +789,7 @@ test_opcode_0x29(void) // NOLINT
   code_found = execute_instruction(&cpu, 0x29); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(2 == cpu.pc);
   CU_ASSERT(0x00 == cpu.h); // NOLINT
   CU_ASSERT(0x00 == cpu.l); // NOLINT
@@ -809,7 +809,7 @@ test_opcode_0x32(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x32); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 3);
   CU_ASSERT(cpu_read_mem(&cpu, 0xBBAA) == cpu.a);
 
@@ -880,7 +880,7 @@ test_opcode_0x3a(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0x3a); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(3 == cpu.pc);
   CU_ASSERT(0x42 == cpu.a); // NOLINT
 
@@ -905,7 +905,7 @@ test_opcode_0x66(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0x66); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0x31 == cpu.h); // NOLINT
 
@@ -926,7 +926,7 @@ test_opcode_0x7b(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0x7b); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0x29 == cpu.a); // NOLINT
   CU_ASSERT(0x29 == cpu.e); // NOLINT
@@ -945,7 +945,7 @@ test_opcode_0xaf(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0xaf); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0x00 == cpu.a); // NOLINT
   CU_ASSERT(FLAG_S != (cpu.flags & FLAG_S));
@@ -970,7 +970,7 @@ test_opcode_0xc5(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0xc5); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0xccca == cpu.sp); // NOLINT
   CU_ASSERT(cpu.b == cpu_read_mem(&cpu, cpu.sp + 1));
@@ -998,7 +998,7 @@ test_opcode_0xd1(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0xd1); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0xcccc == cpu.sp); // NOLINT
   CU_ASSERT(0xcd == cpu.d);    // NOLINT
@@ -1055,7 +1055,7 @@ test_opcode_0xe5(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0xe5); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0xddb9 == cpu.sp); // NOLINT
   CU_ASSERT(cpu.h == cpu_read_mem(&cpu, cpu.sp + 1));
@@ -1081,7 +1081,7 @@ test_opcode_0xf5(void) // NOLINT
   int code_found = execute_instruction(&cpu, 0xf5); // NOLINT
 
   // verify
-  CU_ASSERT(0 == code_found);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(1 == cpu.pc);
   CU_ASSERT(0x4442 == cpu.sp); // NOLINT
   CU_ASSERT(cpu.a == cpu_read_mem(&cpu, cpu.sp + 1));
@@ -1105,7 +1105,7 @@ test_opcode_0x56(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x56); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 1);
   CU_ASSERT(cpu.d == cpu_read_mem(&cpu, 0xBBAA));
 
@@ -1126,7 +1126,7 @@ test_opcode_0x77(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x77); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 1);
   CU_ASSERT(cpu_read_mem(&cpu, 0xBBAA) == cpu.a);
 
@@ -1147,7 +1147,7 @@ test_opcode_0x7e(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0x7e); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 1);
   CU_ASSERT(cpu.a == cpu_read_mem(&cpu, 0xBBAA));
 
@@ -1169,7 +1169,7 @@ test_opcode_0xc2(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xc2); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 3);
   CU_ASSERT((cpu.flags & FLAG_Z) == FLAG_Z);
 
@@ -1179,7 +1179,7 @@ test_opcode_0xc2(void) // NOLINT
 
   code_found = execute_instruction(&cpu, 0xc2); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 0xBBAA);
   CU_ASSERT((cpu.flags & FLAG_Z) == 0);
 
@@ -1202,7 +1202,7 @@ test_opcode_0xc9(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xc9); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 0xBBAA);
   CU_ASSERT(cpu.sp == 0x0003);
 
@@ -1223,7 +1223,7 @@ test_opcode_0xd5(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xd5); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 0x0001);
   CU_ASSERT(cpu.sp == 0xFFFD);
   CU_ASSERT(cpu_read_mem(&cpu, cpu.sp) == cpu.e);
@@ -1247,7 +1247,7 @@ test_opcode_0xeb(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xeb); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 0x0001);
   CU_ASSERT(cpu.d == 0xCC);
   CU_ASSERT(cpu.e == 0xDD);
@@ -1268,7 +1268,7 @@ test_opcode_0xfe(void) // NOLINT
 
   int code_found = execute_instruction(&cpu, 0xfe); // NOLINT
 
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 0x0002);
   CU_ASSERT((cpu.flags & FLAG_P) == FLAG_P);
   CU_ASSERT((cpu.flags & FLAG_S) == 0);
@@ -1277,7 +1277,7 @@ test_opcode_0xfe(void) // NOLINT
   CU_ASSERT((cpu.flags & FLAG_CY) == 0);
 
   code_found = execute_instruction(&cpu, 0xfe); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 0x0004);
   CU_ASSERT((cpu.flags & FLAG_P) == FLAG_P);
   CU_ASSERT((cpu.flags & FLAG_S) == FLAG_S);
@@ -1286,7 +1286,7 @@ test_opcode_0xfe(void) // NOLINT
   CU_ASSERT((cpu.flags & FLAG_CY) == FLAG_CY);
 
   code_found = execute_instruction(&cpu, 0xfe); // NOLINT
-  CU_ASSERT(code_found == 0);
+  CU_ASSERT(code_found >= 0);
   CU_ASSERT(cpu.pc == 0x0006);
   CU_ASSERT((cpu.flags & FLAG_P) == 0);
   CU_ASSERT((cpu.flags & FLAG_S) == 0);


### PR DESCRIPTION
The biggest difference is the change I made so that the running an instruction returns a non-zero value representing the number of cycles. The commit history is a mess and includes several code implementations we have out for review. As we get those reviewed and merged I'll update this branch. so the diff looks less gnarly.