### PR TITLE
Collin Opcodes

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -86,6 +86,24 @@ DAD(i8080 *cpu, int pair)
   return 10; // NOLINT
 }
 
+// Add reg
+int
+add_reg_accum(i8080 *cpu, uint8_t value)
+{
+  uint16_t result = cpu->a + value;
+  update_sign_flag(cpu, result);
+  update_zero_flag(cpu, result);
+  update_aux_carry_flag(cpu, cpu->a, value);
+  update_parity_flag(cpu, result);
+  if (result > MAX_8_BIT_VALUE) {
+    update_carry_flag(cpu, true);
+  } else {
+    update_carry_flag(cpu, false);
+  }
+  cpu->a = (uint8_t)result;
+  return 4; // NOLINT
+}
+
 // Decrement Register
 int
 DCR(i8080 *cpu, uint8_t *reg)
@@ -783,6 +801,48 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
     case 0x7e: // NOLINT
       {        // MOV A,M
         num_cycles = MOV_FROM_MEM(cpu, &cpu->a);
+        break;
+      }
+    case 0x80: // NOLINT
+      {        // ADD B
+        num_cycles = add_reg_accum(cpu, cpu->b);
+        break;
+      }
+    case 0x81: // NOLINT
+      {        // ADD C
+        num_cycles = add_reg_accum(cpu, cpu->c);
+        break;
+      }
+    case 0x82: // NOLINT
+      {        // ADD D
+        num_cycles = add_reg_accum(cpu, cpu->d);
+        break;
+      }
+    case 0x83: // NOLINT
+      {        // ADD E
+        num_cycles = add_reg_accum(cpu, cpu->e);
+        break;
+      }
+    case 0x85: // NOLINT
+      {        // ADD L
+        num_cycles = add_reg_accum(cpu, cpu->l);
+        break;
+      }
+    case 0x86: // NOLINT
+      {        // ADD M
+        uint8_t value = cpu_read_mem(cpu, cpu->pc + 1);
+        uint16_t result = cpu->a + value;
+        update_sign_flag(cpu, result);
+        update_zero_flag(cpu, result);
+        update_aux_carry_flag(cpu, cpu->a, value);
+        update_parity_flag(cpu, result);
+        if (result > MAX_8_BIT_VALUE) {
+          update_carry_flag(cpu, true);
+        } else {
+          update_carry_flag(cpu, false);
+        }
+        cpu->a = (uint8_t)result;
+        num_cycles = 7; // NOLINT
         break;
       }
     case 0xa7: // NOLINT

--- a/emulator.c
+++ b/emulator.c
@@ -833,22 +833,9 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
       }
     case 0x86: // NOLINT
       {        // ADD M
-        uint8_t value = cpu_read_mem(cpu, cpu->pc + 1);
-        uint16_t result = cpu->a + value;
-        update_sign_flag(cpu, result);
-        update_zero_flag(cpu, result);
-        update_aux_carry_flag(cpu, cpu->a, value);
-        update_parity_flag(cpu, result);
-        if (result > MAX_8_BIT_VALUE)
-          {
-            update_carry_flag(cpu, true);
-          }
-        else
-          {
-            update_carry_flag(cpu, false);
-          }
-        cpu->a = (uint8_t)result;
-        num_cycles = 7; // NOLINT
+        num_cycles
+            = add_reg_accum(cpu, cpu_read_mem(cpu, readRegisterPair(cpu, HL)))
+              + 3;
         break;
       }
     case 0xa7: // NOLINT

--- a/emulator.c
+++ b/emulator.c
@@ -95,11 +95,14 @@ add_reg_accum(i8080 *cpu, uint8_t value)
   update_zero_flag(cpu, result);
   update_aux_carry_flag(cpu, cpu->a, value);
   update_parity_flag(cpu, result);
-  if (result > MAX_8_BIT_VALUE) {
-    update_carry_flag(cpu, true);
-  } else {
-    update_carry_flag(cpu, false);
-  }
+  if (result > MAX_8_BIT_VALUE)
+    {
+      update_carry_flag(cpu, true);
+    }
+  else
+    {
+      update_carry_flag(cpu, false);
+    }
   cpu->a = (uint8_t)result;
   return 4; // NOLINT
 }
@@ -836,11 +839,14 @@ execute_instruction(i8080 *cpu, uint8_t opcode)
         update_zero_flag(cpu, result);
         update_aux_carry_flag(cpu, cpu->a, value);
         update_parity_flag(cpu, result);
-        if (result > MAX_8_BIT_VALUE) {
-          update_carry_flag(cpu, true);
-        } else {
-          update_carry_flag(cpu, false);
-        }
+        if (result > MAX_8_BIT_VALUE)
+          {
+            update_carry_flag(cpu, true);
+          }
+        else
+          {
+            update_carry_flag(cpu, false);
+          }
         cpu->a = (uint8_t)result;
         num_cycles = 7; // NOLINT
         break;

--- a/tests.c
+++ b/tests.c
@@ -2258,8 +2258,8 @@ test_opcode_0x86(void)
   cpu_init(&cpu);
 
   cpu.a = 0xF;
-  cpu.pc = 0x2000;
-  cpu_write_mem(&cpu, cpu.pc + 1, 0xF);
+  writeRegisterPair(&cpu, 3, 0xAABB);
+  cpu_write_mem(&cpu, 0xAABB, 0xF);
 
   int code_found = execute_instruction(&cpu, 0x86);
   CU_ASSERT(code_found >= 0);
@@ -2271,8 +2271,8 @@ test_opcode_0x86(void)
   CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), 0);
 
   cpu.a = 0x9;
-  cpu.pc = 0x2000;
-  cpu_write_mem(&cpu, cpu.pc + 1, MAX_8_BIT_VALUE);
+  writeRegisterPair(&cpu, 3, 0xAABB);
+  cpu_write_mem(&cpu, 0xAABB, MAX_8_BIT_VALUE);
 
   // Only 8 bits are kept from addition, the rest discarded and cy flag is set.
   code_found = execute_instruction(&cpu, 0x86);
@@ -2641,20 +2641,15 @@ main(void)
           == CU_add_test(pSuite, "test_handle_interrupt_interrupts_disabled()",
                          test_handle_interrupt_interrupts_disabled))
       || (NULL
-          == CU_add_test(pSuite, "test of test_opcode_0x80",
-                         test_opcode_0x80))
+          == CU_add_test(pSuite, "test of test_opcode_0x80", test_opcode_0x80))
       || (NULL
-          == CU_add_test(pSuite, "test of test_opcode_0x81",
-                         test_opcode_0x81))
+          == CU_add_test(pSuite, "test of test_opcode_0x81", test_opcode_0x81))
       || (NULL
-          == CU_add_test(pSuite, "test of test_opcode_0x82",
-                         test_opcode_0x82))
+          == CU_add_test(pSuite, "test of test_opcode_0x82", test_opcode_0x82))
       || (NULL
-          == CU_add_test(pSuite, "test of test_opcode_0x83",
-                         test_opcode_0x83))
+          == CU_add_test(pSuite, "test of test_opcode_0x83", test_opcode_0x83))
       || (NULL
-          == CU_add_test(pSuite, "test of test_opcode_0x85",
-                         test_opcode_0x85))
+          == CU_add_test(pSuite, "test of test_opcode_0x85", test_opcode_0x85))
       || (NULL
           == CU_add_test(pSuite, "test of test_opcode_0x86",
                          test_opcode_0x86)))

--- a/tests.c
+++ b/tests.c
@@ -2092,6 +2092,202 @@ test_opcode_0xfe(void) // NOLINT
 }
 
 void
+test_opcode_0x80(void)
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+
+  cpu.a = 0xF;
+  cpu.b = 0xF;
+
+  int code_found = execute_instruction(&cpu, 0x80);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x1E);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), FLAG_P);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), 0);
+
+  cpu.a = 0x9;
+  cpu.b = MAX_8_BIT_VALUE;
+
+  // Only 8 bits are kept from addition, the rest discarded and cy flag is set.
+  code_found = execute_instruction(&cpu, 0x80);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x8);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), FLAG_CY);
+}
+
+void
+test_opcode_0x81(void)
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+
+  cpu.a = 0xF;
+  cpu.c = 0xF;
+
+  int code_found = execute_instruction(&cpu, 0x81);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x1E);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), FLAG_P);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), 0);
+
+  cpu.a = 0x9;
+  cpu.c = MAX_8_BIT_VALUE;
+
+  // Only 8 bits are kept from addition, the rest discarded and cy flag is set.
+  code_found = execute_instruction(&cpu, 0x81);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x8);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), FLAG_CY);
+}
+
+void
+test_opcode_0x82(void)
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+
+  cpu.a = 0xF;
+  cpu.d = 0xF;
+
+  int code_found = execute_instruction(&cpu, 0x82);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x1E);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), FLAG_P);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), 0);
+
+  cpu.a = 0x9;
+  cpu.d = MAX_8_BIT_VALUE;
+
+  // Only 8 bits are kept from addition, the rest discarded and cy flag is set.
+  code_found = execute_instruction(&cpu, 0x82);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x8);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), FLAG_CY);
+}
+
+void
+test_opcode_0x83(void)
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+
+  cpu.a = 0xF;
+  cpu.e = 0xF;
+
+  int code_found = execute_instruction(&cpu, 0x83);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x1E);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), FLAG_P);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), 0);
+
+  cpu.a = 0x9;
+  cpu.e = MAX_8_BIT_VALUE;
+
+  // Only 8 bits are kept from addition, the rest discarded and cy flag is set.
+  code_found = execute_instruction(&cpu, 0x83);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x8);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), FLAG_CY);
+}
+
+void
+test_opcode_0x85(void)
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+
+  cpu.a = 0xF;
+  cpu.l = 0xF;
+
+  int code_found = execute_instruction(&cpu, 0x85);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x1E);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), FLAG_P);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), 0);
+
+  cpu.a = 0x9;
+  cpu.l = MAX_8_BIT_VALUE;
+
+  // Only 8 bits are kept from addition, the rest discarded and cy flag is set.
+  code_found = execute_instruction(&cpu, 0x85);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x8);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), FLAG_CY);
+}
+
+void
+test_opcode_0x86(void)
+{
+  i8080 cpu;
+  cpu_init(&cpu);
+
+  cpu.a = 0xF;
+  cpu.pc = 0x2000;
+  cpu_write_mem(&cpu, cpu.pc + 1, 0xF);
+
+  int code_found = execute_instruction(&cpu, 0x86);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x1E);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), FLAG_P);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), 0);
+
+  cpu.a = 0x9;
+  cpu.pc = 0x2000;
+  cpu_write_mem(&cpu, cpu.pc + 1, MAX_8_BIT_VALUE);
+
+  // Only 8 bits are kept from addition, the rest discarded and cy flag is set.
+  code_found = execute_instruction(&cpu, 0x86);
+  CU_ASSERT(code_found >= 0);
+  CU_ASSERT_EQUAL(cpu.a, 0x8);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_Z), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_S), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_P), 0);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_AC), FLAG_AC);
+  CU_ASSERT_EQUAL((cpu.flags & FLAG_CY), FLAG_CY);
+
+  cpu_write_mem(&cpu, cpu.pc + 1, 0x00);
+}
+
+void
 test_handle_interrupt(void) // NOLINT
 {
   i8080 cpu;
@@ -2443,7 +2639,25 @@ main(void)
                          test_handle_interrupt_invalid_rst))
       || (NULL
           == CU_add_test(pSuite, "test_handle_interrupt_interrupts_disabled()",
-                         test_handle_interrupt_interrupts_disabled)))
+                         test_handle_interrupt_interrupts_disabled))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0x80",
+                         test_opcode_0x80))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0x81",
+                         test_opcode_0x81))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0x82",
+                         test_opcode_0x82))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0x83",
+                         test_opcode_0x83))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0x85",
+                         test_opcode_0x85))
+      || (NULL
+          == CU_add_test(pSuite, "test of test_opcode_0x86",
+                         test_opcode_0x86)))
     {
       CU_cleanup_registry();
       return CU_get_error();


### PR DESCRIPTION
Implemented add helper for add register functions:

- add_reg_accum(i8080 *cpu, uint8_t value)

Implemented all add opcodes:

- 0x80 ADD B
- 0x81 ADD C
- 0x82 ADD D
- 0x83 ADD H
- 0x85 ADD L
- 0x86 ADD M

Added unit tests to tests.c for all opcodes.  Double check AC flags?